### PR TITLE
Game behaviours

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,6 +177,7 @@ dependencies = [
  "serde",
  "serde-wasm-bindgen",
  "serde_derive",
+ "typemap",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -269,10 +270,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "traitobject"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079"
+
+[[package]]
+name = "typemap"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "653be63c80a3296da5551e1bfd2cca35227e13cdd08c6668903ae2f4f77aa1f6"
+dependencies = [
+ "unsafe-any",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+
+[[package]]
+name = "unsafe-any"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f30360d7979f5e9c6e6cea48af192ea8fab4afb3cf72597154b8f08935bc9c7f"
+dependencies = [
+ "traitobject",
+]
 
 [[package]]
 name = "wasm-bindgen"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,6 +31,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "derives"
+version = "0.1.0"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -172,12 +180,12 @@ name = "plants-vs-zombies"
 version = "0.1.0"
 dependencies = [
  "console_error_panic_hook",
+ "derives",
  "futures",
  "js-sys",
  "serde",
  "serde-wasm-bindgen",
  "serde_derive",
- "typemap",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -270,34 +278,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "traitobject"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079"
-
-[[package]]
-name = "typemap"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "653be63c80a3296da5551e1bfd2cca35227e13cdd08c6668903ae2f4f77aa1f6"
-dependencies = [
- "unsafe-any",
-]
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
-
-[[package]]
-name = "unsafe-any"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f30360d7979f5e9c6e6cea48af192ea8fab4afb3cf72597154b8f08935bc9c7f"
-dependencies = [
- "traitobject",
-]
 
 [[package]]
 name = "wasm-bindgen"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,7 +177,6 @@ dependencies = [
  "serde",
  "serde-wasm-bindgen",
  "serde_derive",
- "typemap",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -270,34 +269,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "traitobject"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079"
-
-[[package]]
-name = "typemap"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "653be63c80a3296da5551e1bfd2cca35227e13cdd08c6668903ae2f4f77aa1f6"
-dependencies = [
- "unsafe-any",
-]
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
-
-[[package]]
-name = "unsafe-any"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f30360d7979f5e9c6e6cea48af192ea8fab4afb3cf72597154b8f08935bc9c7f"
-dependencies = [
- "traitobject",
-]
 
 [[package]]
 name = "wasm-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ js-sys = "0.3.55"
 serde = { version = "1.0.130", features = ["derive"] }
 serde_derive = "1.0.130"
 serde-wasm-bindgen = "0.4"
-typemap = "0.3.3"
 wasm-bindgen = { version = "0.2.78", features = ["serde-serialize"] }
 wasm-bindgen-futures = "0.4.28"
 console_error_panic_hook = "0.1.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,12 +8,12 @@ edition = "2021"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
+derives = { path = "./derives" }
 futures = "0.3.17"
 js-sys = "0.3.55"
 serde = { version = "1.0.130", features = ["derive"] }
 serde_derive = "1.0.130"
 serde-wasm-bindgen = "0.4"
-typemap = "0.3.3"
 wasm-bindgen = { version = "0.2.78", features = ["serde-serialize"] }
 wasm-bindgen-futures = "0.4.28"
 console_error_panic_hook = "0.1.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ js-sys = "0.3.55"
 serde = { version = "1.0.130", features = ["derive"] }
 serde_derive = "1.0.130"
 serde-wasm-bindgen = "0.4"
+typemap = "0.3.3"
 wasm-bindgen = { version = "0.2.78", features = ["serde-serialize"] }
 wasm-bindgen-futures = "0.4.28"
 console_error_panic_hook = "0.1.7"

--- a/assets/json/interface-data.json
+++ b/assets/json/interface-data.json
@@ -22,7 +22,7 @@
     "constructor": "Sprite",
     "position": [{ "left": 474, "top": 203 }],
     "exact_outlines": true,
-    "behaviors": [{ "name": "Hover" }, { "name": "Click" }]
+    "behaviors": [{ "name": "Hover" }, { "name": "Click", "callback": "StartBattleScene" }]
   },
   "SelectorChallengeShadow": {
     "constructor": "Sprite",
@@ -33,7 +33,7 @@
     "constructor": "Sprite",
     "position": [{ "left": 478, "top": 303 }],
     "exact_outlines": true,
-    "behaviors": [{ "name": "Hover" }, { "name": "Click" }]
+    "behaviors": [{ "name": "Hover" }, { "name": "Click", "callback": "StartBattleScene" }]
   },
   "SelectorZombieHand": {
     "constructor": "Sprite",

--- a/assets/json/interface-data.json
+++ b/assets/json/interface-data.json
@@ -11,7 +11,7 @@
   "SelectorAdventureButton": {
     "constructor": "Sprite",
     "position": [{ "left": 474, "top": 80 }],
-    "normal_shape": false,
+    "exact_outlines": true,
     "behaviors": [{ "name": "Hover" }, { "name": "Click" }]
   },
   "SelectorSurvivalShadow": {
@@ -21,7 +21,7 @@
   "SelectorSurvivalButton": {
     "constructor": "Sprite",
     "position": [{ "left": 474, "top": 203 }],
-    "normal_shape": false,
+    "exact_outlines": true,
     "behaviors": [{ "name": "Hover" }, { "name": "Click" }]
   },
   "SelectorChallengeShadow": {
@@ -32,7 +32,7 @@
   "SelectorChallengeButton": {
     "constructor": "Sprite",
     "position": [{ "left": 478, "top": 303 }],
-    "normal_shape": false,
+    "exact_outlines": true,
     "behaviors": [{ "name": "Hover" }, { "name": "Click" }]
   },
   "SelectorZombieHand": {

--- a/assets/json/interface-data.json
+++ b/assets/json/interface-data.json
@@ -12,7 +12,7 @@
     "constructor": "Sprite",
     "position": [{ "left": 474, "top": 80 }],
     "exact_outlines": true,
-    "behaviors": [{ "name": "Hover" }, { "name": "Click" }]
+    "behaviors": [{ "name": "Hover" }, { "name": "Click", "callback": "StartBattleScene" }]
   },
   "SelectorSurvivalShadow": {
     "constructor": "Sprite",

--- a/derives/Cargo.toml
+++ b/derives/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "derives"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+quote = "1.0.9"
+syn = { version = "1.0.77", features = ["extra-traits"] }

--- a/derives/src/behavior.rs
+++ b/derives/src/behavior.rs
@@ -1,0 +1,32 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{Data, DeriveInput};
+
+pub fn impl_base_bevhior_derive(parsed_input: DeriveInput) -> TokenStream {
+    let struct_name = parsed_input.ident;
+
+    match parsed_input.data {
+        Data::Struct(_s) => {
+            let tokens = quote! {
+                use super::base::BehaviorState;
+
+                impl BehaviorState for #struct_name {
+                    fn start(&mut self, _now: f64) {
+                        self.running = true;
+                    }
+
+                    fn stop(&mut self, _now: f64) {
+                        self.running = false;
+                    }
+
+                    fn is_running(&self) -> bool {
+                        self.running
+                    }
+                }
+            };
+
+            proc_macro::TokenStream::from(tokens)
+        }
+        other => panic!("Cannot implement BehaviorState for: {:?}", other),
+    }
+}

--- a/derives/src/behavior_field.rs
+++ b/derives/src/behavior_field.rs
@@ -1,0 +1,73 @@
+use proc_macro::{Delimiter, Group, Ident, TokenStream, TokenTree};
+use quote::quote;
+use syn::parse::{Parse, ParseStream};
+
+#[derive(Debug)]
+pub enum BehaviorDerivedType {
+    DEFAULT
+}
+
+#[derive(Debug)]
+pub struct BehaviorMacroInput {
+    pub kind: BehaviorDerivedType,
+}
+
+impl BehaviorMacroInput {
+    pub fn new(kind: String) -> Self {
+        let derived_kind = match kind {
+            _ => BehaviorDerivedType::DEFAULT
+        };
+
+        Self { kind: derived_kind }
+    }
+}
+
+impl Parse for BehaviorMacroInput {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let kind = input.parse::<syn::LitStr>()?;
+
+        Ok(BehaviorMacroInput::new(kind.value()))
+    }
+}
+
+impl BehaviorMacroInput {
+    pub fn get_fields(&self) -> Vec<TokenStream> {
+        match &self.kind {
+            BehaviorDerivedType::DEFAULT => vec![
+                quote!(running: bool,).into(),
+                quote!(interaction_active: bool,).into(),
+            ]
+        }
+    }
+}
+
+pub fn get_derived_behavior_feilds(input: BehaviorMacroInput, item: TokenStream) -> TokenStream {
+    let mut found_struct = false;
+
+    item.into_iter()
+        .map(|token_tree| match &token_tree {
+            &TokenTree::Ident(ref ident) if is_struct(ident) => {
+                found_struct = true;
+                token_tree
+            }
+            &TokenTree::Group(ref group) if is_brace(group.delimiter()) && found_struct => {
+                let mut stream = TokenStream::new();
+                let fields = input.get_fields();
+
+                stream.extend(fields.into_iter());
+                stream.extend(group.stream());
+
+                TokenTree::Group(Group::new(Delimiter::Brace, stream))
+            }
+            _ => token_tree,
+        })
+        .collect()
+}
+
+fn is_struct(ident: &Ident) -> bool {
+    ident.to_string() == "struct"
+}
+
+fn is_brace(delimiter: Delimiter) -> bool {
+    matches!(delimiter, Delimiter::Brace)
+}

--- a/derives/src/lib.rs
+++ b/derives/src/lib.rs
@@ -1,0 +1,23 @@
+mod behavior;
+mod behavior_field;
+
+extern crate proc_macro;
+
+use proc_macro::{TokenStream};
+use syn::{parse_macro_input, DeriveInput};
+use behavior_field::{get_derived_behavior_feilds, BehaviorMacroInput};
+use behavior::{impl_base_bevhior_derive};
+
+#[proc_macro_derive(BaseBehavior)]
+pub fn base_bahvior_derive(input: TokenStream) -> TokenStream {
+    let parsed_input: DeriveInput = parse_macro_input!(input);
+
+    impl_base_bevhior_derive(parsed_input)
+}
+
+#[proc_macro_attribute]
+pub fn derive_behavior_fields(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let input = syn::parse_macro_input!(attr as BehaviorMacroInput);
+
+    get_derived_behavior_feilds(input, item)
+}

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -114,19 +114,10 @@ impl Engine {
         let initial_trigger_ref = Rc::clone(&main_loop_ref);
 
         let game = Rc::clone(&self.game);
-        let mut iter = 0;
         *initial_trigger_ref.borrow_mut() = Some(Closure::wrap(Box::new(move || {
             let mut game = game.borrow_mut();
-            iter += 1;
 
             game.run();
-
-            if iter > 1000 {
-                log!("Game done");
-                game.game_over();
-                let _ = main_loop_ref.borrow_mut().take();
-                return;
-            }
 
             request_animation_frame(main_loop_ref.borrow().as_ref().unwrap());
         }) as Box<dyn FnMut()>));

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -7,14 +7,13 @@ use wasm_bindgen_futures::spawn_local;
 use web_sys::MouseEvent;
 
 use crate::game::Game;
-use crate::log;
-use crate::model::GameEvent;
+use crate::model::GameMouseEvent;
 use crate::resource_loader::ResourceLoader;
 use crate::web_utils::request_animation_frame;
 
 pub struct Engine {
     game: Rc<RefCell<Game>>,
-    handled_events: Vec<GameEvent>,
+    handled_events: Vec<GameMouseEvent>,
 }
 
 impl Default for Engine {
@@ -22,10 +21,10 @@ impl Default for Engine {
         Engine {
             game: Rc::new(RefCell::new(Game::new())),
             handled_events: vec![
-                GameEvent::MouseMove,
-                GameEvent::MouseUp,
-                GameEvent::MouseLeave,
-                GameEvent::MouseDown,
+                GameMouseEvent::MouseMove,
+                GameMouseEvent::MouseUp,
+                GameMouseEvent::MouseLeave,
+                GameMouseEvent::MouseDown,
             ],
         }
     }
@@ -85,11 +84,13 @@ impl Engine {
             .for_each(|event| self.listen_event(*event));
     }
 
-    fn listen_event(&self, name: GameEvent) {
+    fn listen_event(&self, name: GameMouseEvent) {
         let game_closure_ref = Rc::clone(&self.game);
 
         let closure = Closure::wrap(Box::new(move |event: MouseEvent| {
-            game_closure_ref.borrow_mut().handle_event(name, event);
+            game_closure_ref
+                .borrow_mut()
+                .handle_mouse_event(name, event);
         }) as Box<dyn FnMut(_)>);
 
         self.game

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -22,11 +22,10 @@ impl Default for Engine {
         Engine {
             game: Rc::new(RefCell::new(Game::new())),
             handled_events: vec![
-                GameEvent::Mousemove,
-                GameEvent::Mouseup,
-                GameEvent::Mouseleave,
-                GameEvent::Mouseenter,
-                GameEvent::Mousedown,
+                GameEvent::MouseMove,
+                GameEvent::MouseUp,
+                GameEvent::MouseLeave,
+                GameEvent::MouseDown,
             ],
         }
     }

--- a/src/game.rs
+++ b/src/game.rs
@@ -115,7 +115,7 @@ impl Game {
         log!("Game handling click event for {:?}", callback);
 
         match callback {
-            Callback::StartBattleScene => log!("[Game Callback] Starting Battle scene")
+            Callback::StartBattleScene => log!("[Game Callback] Starting Battle scene"),
         }
     }
 

--- a/src/game.rs
+++ b/src/game.rs
@@ -91,7 +91,7 @@ impl Game {
     }
 
     pub fn toggle_game_behavior(&mut self, active: bool, types: &[BehaviorType]) {
-        BehaviorManager::toggle_behaviors(self.sprites.iter_mut(), types, active, self.game_time.time)
+        BehaviorManager::toggle_behaviors(self.sprites.iter(), types, active, self.game_time.time)
     }
 
     // Game Actions //

--- a/src/game.rs
+++ b/src/game.rs
@@ -2,7 +2,7 @@ use web_sys::{HtmlCanvasElement, MouseEvent};
 
 use crate::fps::Fps;
 use crate::log;
-use crate::model::{BehaviorType, GameInteraction, GameMouseEvent, GameState, Position};
+use crate::model::{BehaviorType, Callback, GameInteraction, GameMouseEvent, GameState, Position};
 use crate::painter::Painter;
 use crate::resource_loader::Resources;
 use crate::scene::HomeScene;
@@ -107,12 +107,16 @@ impl Game {
         game_interactions
             .iter()
             .for_each(|interaction| match interaction {
-                GameInteraction::SpriteClick(name) => self.on_sprite_click(name),
+                GameInteraction::SpriteClick(callback) => self.on_sprite_click(callback),
             });
     }
 
-    pub fn on_sprite_click(&mut self, clicked_sprite_name: &String) {
-        log!("Game handling click event for {}", clicked_sprite_name);
+    pub fn on_sprite_click(&mut self, callback: &Callback) {
+        log!("Game handling click event for {:?}", callback);
+
+        match callback {
+            Callback::StartBattleScene => log!("[Game Callback] Starting Battle scene")
+        }
     }
 
     // Game Actions //

--- a/src/game.rs
+++ b/src/game.rs
@@ -1,4 +1,5 @@
 use web_sys::{HtmlCanvasElement, MouseEvent};
+
 use crate::fps::Fps;
 use crate::log;
 use crate::model::{GameEvent, GameState};
@@ -50,7 +51,6 @@ impl Game {
 
         // TODO - SunGenerator::tick()
 
-        log!("Running game tick with {} Sprites", self.sprites.len());
         self.fps.set(current_time);
     }
 

--- a/src/game.rs
+++ b/src/game.rs
@@ -84,8 +84,8 @@ impl Game {
 
         match event_name {
             GameEvent::MouseMove => self.toggle_game_behavior(true, &[BehaviorType::Hover]),
-            GameEvent::MouseDown => {}
-            GameEvent::MouseUp => {}
+            GameEvent::MouseDown => self.toggle_game_behavior(true, &[BehaviorType::Click]),
+            GameEvent::MouseUp => self.toggle_game_behavior(false, &[BehaviorType::Click]),
             GameEvent::MouseLeave => self.toggle_game_behavior(false, &[BehaviorType::Hover]),
         }
     }

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,6 +1,7 @@
 use std::fmt;
 
 use serde_derive::Deserialize;
+use web_sys::MouseEvent;
 
 #[derive(Debug, Default)]
 pub struct GameState {
@@ -20,11 +21,10 @@ impl GameState {
 /// The events being listened by our game.
 #[derive(Debug, Clone, Copy)]
 pub enum GameEvent {
-    Mousedown,
-    Mousemove,
-    Mouseup,
-    Mouseleave,
-    Mouseenter,
+    MouseDown,
+    MouseMove,
+    MouseUp,
+    MouseLeave,
 }
 
 impl fmt::Display for GameEvent {
@@ -89,6 +89,13 @@ pub struct Position {
 impl Position {
     pub fn new(top: f64, left: f64) -> Self {
         Self { top, left }
+    }
+
+    pub fn from_event(event: MouseEvent) -> Self {
+        Self {
+            top: event.offset_y() as f64,
+            left: event.offset_x() as f64,
+        }
     }
 }
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -38,6 +38,12 @@ pub enum Callback {
     StartBattleScene,
 }
 
+impl Default for Callback {
+    fn default() -> Callback {
+        Callback::StartBattleScene
+    }
+}
+
 #[derive(Debug)]
 pub enum GameInteraction {
     SpriteClick(Callback),

--- a/src/model.rs
+++ b/src/model.rs
@@ -67,6 +67,27 @@ pub struct Position {
     pub top: f64,
 }
 
+impl Position {
+    pub fn new(top: f64, left: f64) -> Self {
+        Self { top, left }
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct Size {
+    pub width: f64,
+    pub height: f64,
+}
+
+impl From<&SpriteCell> for Size {
+    fn from(cell: &SpriteCell) -> Size {
+        Size {
+            width: cell.width,
+            height: cell.height,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Deserialize)]
 pub struct LevelData {
     pub name: String,

--- a/src/model.rs
+++ b/src/model.rs
@@ -33,9 +33,14 @@ impl fmt::Display for GameMouseEvent {
     }
 }
 
+#[derive(Debug, Clone, Copy, Deserialize)]
+pub enum Callback {
+    StartBattleScene,
+}
+
 #[derive(Debug)]
 pub enum GameInteraction {
-    SpriteClick(String),
+    SpriteClick(Callback),
 }
 
 /// Sprite cell represents a Sprite given possible states position pointing to a respective interface asset.
@@ -95,6 +100,7 @@ impl BehaviorType {
 #[derive(Debug, Clone, Deserialize)]
 pub struct BehaviorData {
     pub name: String,
+    pub callback: Option<Callback>
 }
 
 #[derive(Debug, Default, PartialEq, Clone, Copy, Deserialize)]

--- a/src/model.rs
+++ b/src/model.rs
@@ -49,6 +49,7 @@ pub struct SpriteData {
     pub position: Vec<Position>,
     pub order: usize,
     pub scale: f64,
+    pub exact_outlines: bool,
     pub behaviors: Vec<BehaviorData>,
 }
 
@@ -58,6 +59,7 @@ impl Default for SpriteData {
             position: vec![Position::default()],
             order: 1,
             scale: 1.0,
+            exact_outlines: false,
             behaviors: vec![],
         }
     }

--- a/src/model.rs
+++ b/src/model.rs
@@ -20,17 +20,22 @@ impl GameState {
 
 /// The events being listened by our game.
 #[derive(Debug, Clone, Copy)]
-pub enum GameEvent {
+pub enum GameMouseEvent {
     MouseDown,
     MouseMove,
     MouseUp,
     MouseLeave,
 }
 
-impl fmt::Display for GameEvent {
+impl fmt::Display for GameMouseEvent {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Debug::fmt(self, f)
     }
+}
+
+#[derive(Debug)]
+pub enum GameInteraction {
+    SpriteClick(String),
 }
 
 /// Sprite cell represents a Sprite given possible states position pointing to a respective interface asset.
@@ -74,6 +79,16 @@ pub enum BehaviorType {
 impl Default for BehaviorType {
     fn default() -> BehaviorType {
         BehaviorType::Click
+    }
+}
+
+impl BehaviorType {
+    pub fn from_string(name: &str) -> BehaviorType {
+        match name {
+            "Click" => BehaviorType::Click,
+            "Hover" => BehaviorType::Hover,
+            _ => BehaviorType::default(),
+        }
     }
 }
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -49,6 +49,7 @@ pub struct SpriteData {
     pub position: Vec<Position>,
     pub order: usize,
     pub scale: f64,
+    pub behaviors: Vec<BehaviorData>,
 }
 
 impl Default for SpriteData {
@@ -57,8 +58,26 @@ impl Default for SpriteData {
             position: vec![Position::default()],
             order: 1,
             scale: 1.0,
+            behaviors: vec![],
         }
     }
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq)]
+pub enum BehaviorType {
+    Hover,
+    Click,
+}
+
+impl Default for BehaviorType {
+    fn default() -> BehaviorType {
+        BehaviorType::Click
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct BehaviorData {
+    pub name: String,
 }
 
 #[derive(Debug, Default, PartialEq, Clone, Copy, Deserialize)]

--- a/src/model.rs
+++ b/src/model.rs
@@ -100,7 +100,7 @@ impl BehaviorType {
 #[derive(Debug, Clone, Deserialize)]
 pub struct BehaviorData {
     pub name: String,
-    pub callback: Option<Callback>
+    pub callback: Option<Callback>,
 }
 
 #[derive(Debug, Default, PartialEq, Clone, Copy, Deserialize)]

--- a/src/painter.rs
+++ b/src/painter.rs
@@ -74,9 +74,8 @@ impl Painter {
         }
 
         context.save();
-
+        context.set_global_alpha(0.0);
         context.begin_path();
-        context.set_stroke_style(&"#00CCFF".into());
 
         let first = outline.get(0).unwrap();
         context.move_to(first.left, first.top);

--- a/src/painter.rs
+++ b/src/painter.rs
@@ -4,7 +4,7 @@ use web_sys::{CanvasRenderingContext2d, HtmlCanvasElement, HtmlImageElement};
 
 use crate::constants::{CANVAS_HEIGHT, CANVAS_HEIGHT_F64, CANVAS_WIDTH, CANVAS_WIDTH_F64};
 use crate::log;
-use crate::model::{Position, SpriteCell};
+use crate::model::{Position, Size, SpriteCell};
 use crate::sprite::{DrawingState, Sprite};
 use crate::web_utils::{create_canvas, get_canvas_context};
 
@@ -15,7 +15,7 @@ pub struct Painter {
 
 impl Painter {
     pub fn new() -> Self {
-        let canvas = create_canvas(CANVAS_WIDTH, CANVAS_HEIGHT);
+        let canvas = create_canvas(CANVAS_WIDTH, CANVAS_HEIGHT, true);
         let context = get_canvas_context(&canvas);
 
         Self { canvas, context }
@@ -27,7 +27,6 @@ impl Painter {
     }
 
     pub fn draw_sprite(&self, sprite: &Sprite) {
-        log!("Drawing {}", sprite.name);
         let (cell, position) = DrawingState::get(sprite);
 
         // Draw Sprite according to it's type.
@@ -36,7 +35,7 @@ impl Painter {
                 .upgrade()
                 .expect("[Painter] - Cannot draw Image is not available");
 
-            self.draw_image(image_ref, position, cell, sprite.scale);
+            self.draw_image(&image_ref, position, cell, sprite.drawing_state.scale);
         }
 
         // TODO TextSprite case
@@ -44,14 +43,14 @@ impl Painter {
 
     pub fn draw_image(
         &self,
-        image: Rc<HtmlImageElement>,
+        image: &Rc<HtmlImageElement>,
         pos: &Position,
         cell: &SpriteCell,
         scale: f64,
     ) {
         self.context
             .draw_image_with_html_image_element_and_sw_and_sh_and_dx_and_dy_and_dw_and_dh(
-                image.as_ref(),
+                image,
                 cell.left,
                 cell.top,
                 cell.width,
@@ -62,5 +61,16 @@ impl Painter {
                 cell.height * scale,
             )
             .unwrap();
+    }
+
+    pub fn get_measurements_painter(size: Size) -> Painter {
+        let measurements_canvas = create_canvas(size.width as u32, size.width as u32, false);
+
+        let measurements_context = get_canvas_context(&measurements_canvas);
+
+        Painter {
+            canvas: measurements_canvas,
+            context: measurements_context,
+        }
     }
 }

--- a/src/painter.rs
+++ b/src/painter.rs
@@ -63,6 +63,38 @@ impl Painter {
             .unwrap();
     }
 
+    pub fn in_path(
+        outline: &Vec<Position>,
+        point: &Position,
+        context: &CanvasRenderingContext2d,
+    ) -> bool {
+        // Draw outline within context
+        if outline.is_empty() {
+            return false;
+        }
+
+        context.save();
+
+        context.begin_path();
+        context.set_stroke_style(&"#00CCFF".into());
+
+        let first = outline.get(0).unwrap();
+        context.move_to(first.left, first.top);
+
+        outline
+            .iter()
+            .skip(1)
+            .for_each(|path| context.line_to(path.left, path.top));
+
+        context.close_path();
+        context.stroke();
+
+        context.restore();
+
+        // Check rather if point is within that shape.
+        context.is_point_in_path_with_f64(point.left, point.top)
+    }
+
     pub fn get_measurements_painter(size: Size) -> Painter {
         let measurements_canvas = create_canvas(size.width as u32, size.width as u32, false);
 

--- a/src/painter.rs
+++ b/src/painter.rs
@@ -3,7 +3,6 @@ use std::rc::Rc;
 use web_sys::{CanvasRenderingContext2d, HtmlCanvasElement, HtmlImageElement};
 
 use crate::constants::{CANVAS_HEIGHT, CANVAS_HEIGHT_F64, CANVAS_WIDTH, CANVAS_WIDTH_F64};
-use crate::log;
 use crate::model::{Position, Size, SpriteCell};
 use crate::sprite::{DrawingState, Sprite};
 use crate::web_utils::{create_canvas, get_canvas_context};

--- a/src/painter.rs
+++ b/src/painter.rs
@@ -68,7 +68,6 @@ impl Painter {
         point: &Position,
         context: &CanvasRenderingContext2d,
     ) -> bool {
-        // Draw outline within context
         if outline.is_empty() {
             return false;
         }
@@ -80,6 +79,7 @@ impl Painter {
         let first = outline.get(0).unwrap();
         context.move_to(first.left, first.top);
 
+        // Draw outline within context
         outline
             .iter()
             .skip(1)

--- a/src/scene/home.rs
+++ b/src/scene/home.rs
@@ -16,7 +16,7 @@ impl HomeScene {
             &game.resources,
         );
 
-        let outline = Outline::get_outlines(sprites.get(1).unwrap(), Some(true));
+        let outline = Outline::get_outlines(sprites.get(1).unwrap(), true);
 
         log!("Outlines {:?}", outline);
 

--- a/src/scene/home.rs
+++ b/src/scene/home.rs
@@ -5,8 +5,23 @@ use crate::sprite::Sprite;
 pub struct HomeScene;
 
 impl HomeScene {
+    pub fn home_sprites() -> Vec<&'static str> {
+        vec![
+            "SelectorBackground",
+            "SelectorAdventureShadow",
+            "SelectorSurvivalShadow",
+            "SelectorChallengeShadow",
+            "SelectorWoodSign1",
+            "SelectorWoodSign2",
+            "SelectorWoodSign3",
+            "SelectorAdventureButton",
+            "SelectorSurvivalButton",
+            "SelectorChallengeButton",
+        ]
+    }
+
     pub fn start(game: &mut Game) {
-        let scene_sprites_name = vec!["SelectorBackground", "SelectorAdventureButton"];
+        let scene_sprites_name = HomeScene::home_sprites();
 
         // Convert each scene sprites into a actual Sprite using it's corresponding Game.Resource
         let mut sprites = Sprite::create_sprites(

--- a/src/scene/home.rs
+++ b/src/scene/home.rs
@@ -1,7 +1,6 @@
 use crate::game::Game;
-use crate::log;
 use crate::resource_loader::ResourceKind;
-use crate::sprite::{Outline, Sprite};
+use crate::sprite::Sprite;
 
 pub struct HomeScene;
 

--- a/src/scene/home.rs
+++ b/src/scene/home.rs
@@ -16,6 +16,7 @@ impl HomeScene {
             &game.resources,
         );
 
+        // TODO calc outline on creation?
         let outline = Outline::get_outlines(sprites.get(1).unwrap(), true);
 
         log!("Outlines {:?}", outline);

--- a/src/scene/home.rs
+++ b/src/scene/home.rs
@@ -16,11 +16,6 @@ impl HomeScene {
             &game.resources,
         );
 
-        // TODO calc outline on creation?
-        let outline = Outline::get_outlines(sprites.get(1).unwrap(), true);
-
-        log!("Outlines {:?}", outline);
-
         // Adding scene sprites into game.
         game.add_sprites(sprites.as_mut());
     }

--- a/src/scene/home.rs
+++ b/src/scene/home.rs
@@ -1,23 +1,13 @@
 use crate::game::Game;
+use crate::log;
 use crate::resource_loader::ResourceKind;
-use crate::sprite::Sprite;
+use crate::sprite::{Outline, Sprite};
 
 pub struct HomeScene;
 
 impl HomeScene {
     pub fn start(game: &mut Game) {
-        let scene_sprites_name = vec![
-            "SelectorBackground",
-            "SelectorAdventureShadow",
-            "SelectorSurvivalShadow",
-            "SelectorChallengeShadow",
-            "SelectorWoodSign1",
-            "SelectorWoodSign2",
-            "SelectorWoodSign3",
-            "SelectorAdventureButton",
-            "SelectorSurvivalButton",
-            "SelectorChallengeButton",
-        ];
+        let scene_sprites_name = vec!["SelectorBackground", "SelectorAdventureButton"];
 
         // Convert each scene sprites into a actual Sprite using it's corresponding Game.Resource
         let mut sprites = Sprite::create_sprites(
@@ -25,6 +15,10 @@ impl HomeScene {
             &ResourceKind::Interface,
             &game.resources,
         );
+
+        let outline = Outline::get_outlines(sprites.get(1).unwrap(), Some(true));
+
+        log!("Outlines {:?}", outline);
 
         // Adding scene sprites into game.
         game.add_sprites(sprites.as_mut());

--- a/src/sprite/base.rs
+++ b/src/sprite/base.rs
@@ -1,4 +1,5 @@
-use std::rc::Weak;
+use std::cell::RefCell;
+use std::rc::{Rc, Weak};
 
 use js_sys::Math;
 use web_sys::HtmlImageElement;
@@ -51,7 +52,7 @@ pub struct Sprite {
     pub order: usize,
     pub position: Vec<Position>,
     pub outlines: Vec<Position>,
-    pub behaviors: Vec<Box<dyn Behavior>>,
+    pub behaviors: RefCell<Vec<Box<dyn Behavior>>>,
     pub cells: Vec<SpriteCell>,
     pub image: Option<Weak<HtmlImageElement>>,
     pub drawing_state: DrawingState,
@@ -68,13 +69,14 @@ impl Sprite {
         behaviors: Vec<BehaviorData>,
     ) -> Sprite {
         let id = uid(name);
-        let sprite_behaviors = behaviors
-            .iter()
-            .map(|behavior_data| {
-                log!("Adding behaviour for {} / {:?}", name, behavior_data.name);
-                BehaviorManager::create(&id, &behavior_data.name)
-            })
-            .collect();
+        let sprite_behaviors = RefCell::new(
+            behaviors
+                .iter()
+                .map(|behavior_data| {
+                    BehaviorManager::create(&id, &behavior_data.name)
+                })
+                .collect(),
+        );
 
         Sprite {
             id,

--- a/src/sprite/base.rs
+++ b/src/sprite/base.rs
@@ -68,18 +68,15 @@ impl Sprite {
         scale: f64,
         behaviors: Vec<BehaviorData>,
     ) -> Sprite {
-        let id = uid(name);
         let sprite_behaviors = RefCell::new(
             behaviors
                 .iter()
-                .map(|behavior_data| {
-                    BehaviorManager::create(&id, &behavior_data.name)
-                })
+                .map(|behavior_data| BehaviorManager::create(&behavior_data))
                 .collect(),
         );
 
         Sprite {
-            id,
+            id: uid(name),
             name: String::from(name),
             order,
             position,
@@ -129,7 +126,7 @@ impl Sprite {
         mutations.iter().for_each(|mutation| {
             log!("Apply sprite mutation {}", self.id);
             if let Some(hovered) = mutation.hovered {
-                log!("Sprite Hovered!");
+                log!("Sprite Hovered! {}", hovered);
             }
 
             if let Some(clicked) = mutation.clicked {

--- a/src/sprite/base.rs
+++ b/src/sprite/base.rs
@@ -67,7 +67,7 @@ impl Sprite {
         image: Option<Weak<HtmlImageElement>>,
         scale: f64,
         behaviors: Vec<BehaviorData>,
-        exact_outlines: bool
+        exact_outlines: bool,
     ) -> Sprite {
         let sprite_behaviors = RefCell::new(
             behaviors
@@ -88,10 +88,7 @@ impl Sprite {
             behaviors: sprite_behaviors,
         };
 
-        sprite.outlines = Outline::get_outlines(
-            &sprite,
-            exact_outlines
-        );
+        sprite.outlines = Outline::get_outlines(&sprite, exact_outlines);
 
         sprite
     }
@@ -128,7 +125,7 @@ impl Sprite {
             resource.image,
             scale,
             behaviors,
-            exact_outlines
+            exact_outlines,
         )
     }
 
@@ -144,7 +141,11 @@ impl Sprite {
             }
 
             if let Some(clicked) = mutation.clicked {
-                log!("Sprite clicked")
+                if !clicked {
+                    return;
+                }
+
+                log!("Sprite clicked! {}", self.id);
             }
 
             if let Some(position) = mutation.position {

--- a/src/sprite/base.rs
+++ b/src/sprite/base.rs
@@ -1,5 +1,5 @@
 use std::cell::{RefCell, RefMut};
-use std::rc::{Rc, Weak};
+use std::rc::Weak;
 
 use js_sys::Math;
 use web_sys::HtmlImageElement;
@@ -140,16 +140,8 @@ impl Sprite {
                 self.drawing_state.active_cell = 1;
             }
 
-            if let Some(clicked) = mutation.clicked {
-                if !clicked {
-                    return;
-                }
-
-                log!("Sprite clicked! {}", self.id);
-            }
-
             if let Some(position) = mutation.position {
-                log!("Sprite position Changed")
+                log!("TODO - Sprite position Changed")
             }
         });
     }

--- a/src/sprite/base.rs
+++ b/src/sprite/base.rs
@@ -10,9 +10,17 @@ use crate::resource_loader::{ResourceKind, Resources};
 pub struct DrawingState {
     pub active_cell: usize,
     pub active_position: usize,
+    pub scale: f64,
 }
 
 impl DrawingState {
+    pub fn new(scale: f64) -> Self {
+        Self {
+            scale,
+            ..DrawingState::default()
+        }
+    }
+
     pub fn get(sprite: &Sprite) -> (&SpriteCell, &Position) {
         let cell = sprite
             .cells
@@ -42,7 +50,6 @@ pub struct Sprite {
     pub position: Vec<Position>,
     pub cells: Vec<SpriteCell>,
     pub image: Option<Weak<HtmlImageElement>>,
-    pub scale: f64,
     pub drawing_state: DrawingState,
 }
 
@@ -62,8 +69,7 @@ impl Sprite {
             position,
             cells,
             image,
-            scale,
-            drawing_state: DrawingState::default(),
+            drawing_state: DrawingState::new(scale),
         }
     }
 

--- a/src/sprite/base.rs
+++ b/src/sprite/base.rs
@@ -48,6 +48,7 @@ pub struct Sprite {
     pub name: String,
     pub order: usize,
     pub position: Vec<Position>,
+    pub outlines: Vec<Position>,
     pub cells: Vec<SpriteCell>,
     pub image: Option<Weak<HtmlImageElement>>,
     pub drawing_state: DrawingState,
@@ -70,6 +71,7 @@ impl Sprite {
             cells,
             image,
             drawing_state: DrawingState::new(scale),
+            outlines: vec![]
         }
     }
 

--- a/src/sprite/base.rs
+++ b/src/sprite/base.rs
@@ -7,6 +7,7 @@ use crate::log;
 use crate::model::{BehaviorData, Position, SpriteCell, SpriteData};
 use crate::resource_loader::{ResourceKind, Resources};
 use crate::sprite::behavior::{Behavior, BehaviorManager};
+use crate::sprite::SpriteMutation;
 
 #[derive(Debug, Default)]
 pub struct DrawingState {
@@ -120,6 +121,23 @@ impl Sprite {
             scale,
             behaviors,
         )
+    }
+
+    pub fn apply_mutation(&mut self, mutations: Vec<SpriteMutation>) {
+        mutations.iter().for_each(|mutation| {
+            log!("Apply sprite mutation {}", self.id);
+            if let Some(hovered) = mutation.hovered {
+                log!("Sprite Hovered!");
+            }
+
+            if let Some(clicked) = mutation.clicked {
+                log!("Sprite clicked")
+            }
+
+            if let Some(position) = mutation.position {
+                log!("Sprite position Changed")
+            }
+        });
     }
 }
 

--- a/src/sprite/base.rs
+++ b/src/sprite/base.rs
@@ -1,4 +1,4 @@
-use std::cell::RefCell;
+use std::cell::{RefCell, RefMut};
 use std::rc::{Rc, Weak};
 
 use js_sys::Math;
@@ -140,6 +140,10 @@ impl Sprite {
                 log!("Sprite position Changed")
             }
         });
+    }
+
+    pub fn mutable_behaviors(&self) -> RefMut<'_, Vec<Box<dyn Behavior>>> {
+        self.behaviors.borrow_mut()
     }
 }
 

--- a/src/sprite/behavior/base.rs
+++ b/src/sprite/behavior/base.rs
@@ -1,7 +1,7 @@
 use web_sys::CanvasRenderingContext2d;
 
 use crate::model::{BehaviorType, Position};
-use crate::sprite::SpriteMutation;
+use crate::sprite::{Sprite, SpriteMutation};
 
 pub trait BehaviorState {
     fn start(&mut self, now: f64);
@@ -25,6 +25,7 @@ pub trait Behavior: BehaviorState {
 
     fn execute(
         &mut self,
+        sprite: &Sprite,
         now: f64,
         last_frame: f64,
         mouse: &Position,

--- a/src/sprite/behavior/base.rs
+++ b/src/sprite/behavior/base.rs
@@ -1,0 +1,33 @@
+use web_sys::CanvasRenderingContext2d;
+
+use crate::model::{BehaviorType, Position};
+use crate::sprite::{Sprite, SpriteMutation};
+
+pub trait BehaviorState {
+    fn start(&mut self, now: f64);
+
+    fn stop(&mut self, now: f64);
+
+    fn is_running(&self) -> bool;
+
+    fn toggle(&mut self, run: bool, now: f64) {
+        match run {
+            true => self.start(now),
+            false => self.stop(now),
+        }
+    }
+}
+
+pub trait Behavior: BehaviorState {
+    fn id(&self) -> &String;
+
+    fn name(&self) -> BehaviorType;
+
+    fn execute(
+        &mut self,
+        now: f64,
+        last_frame: f64,
+        mouse: &Position,
+        context: &CanvasRenderingContext2d,
+    ) -> Option<SpriteMutation>;
+}

--- a/src/sprite/behavior/base.rs
+++ b/src/sprite/behavior/base.rs
@@ -1,7 +1,7 @@
 use web_sys::CanvasRenderingContext2d;
 
 use crate::model::{BehaviorType, Position};
-use crate::sprite::{Sprite, SpriteMutation};
+use crate::sprite::SpriteMutation;
 
 pub trait BehaviorState {
     fn start(&mut self, now: f64);

--- a/src/sprite/behavior/base.rs
+++ b/src/sprite/behavior/base.rs
@@ -1,6 +1,6 @@
 use web_sys::CanvasRenderingContext2d;
 
-use crate::model::{BehaviorType, Position};
+use crate::model::{BehaviorType, GameInteraction, Position};
 use crate::sprite::{Sprite, SpriteMutation};
 
 pub trait BehaviorState {
@@ -21,6 +21,12 @@ pub trait BehaviorState {
 
 pub trait Behavior: BehaviorState {
     fn name(&self) -> BehaviorType;
+
+    fn get_interaction(&self) -> Option<GameInteraction> {
+        return None;
+    }
+
+    fn clean_interaction(&mut self) {}
 
     fn execute(
         &mut self,

--- a/src/sprite/behavior/base.rs
+++ b/src/sprite/behavior/base.rs
@@ -4,6 +4,7 @@ use crate::model::{BehaviorType, Position};
 use crate::sprite::{Sprite, SpriteMutation};
 
 pub trait BehaviorState {
+    // TODO - Extract to derived
     fn start(&mut self, now: f64);
 
     fn stop(&mut self, now: f64);

--- a/src/sprite/behavior/base.rs
+++ b/src/sprite/behavior/base.rs
@@ -19,8 +19,6 @@ pub trait BehaviorState {
 }
 
 pub trait Behavior: BehaviorState {
-    fn id(&self) -> &String; // TODO Remove, uneeded.
-
     fn name(&self) -> BehaviorType;
 
     fn execute(

--- a/src/sprite/behavior/base.rs
+++ b/src/sprite/behavior/base.rs
@@ -19,7 +19,7 @@ pub trait BehaviorState {
 }
 
 pub trait Behavior: BehaviorState {
-    fn id(&self) -> &String;
+    fn id(&self) -> &String; // TODO Remove, uneeded.
 
     fn name(&self) -> BehaviorType;
 

--- a/src/sprite/behavior/click.rs
+++ b/src/sprite/behavior/click.rs
@@ -1,0 +1,58 @@
+use web_sys::CanvasRenderingContext2d;
+
+use super::base::{Behavior, BehaviorState};
+use crate::log;
+use crate::model::{BehaviorType, Position};
+use crate::sprite::SpriteMutation;
+
+pub struct Click {
+    name: BehaviorType,
+    running: bool,
+    id: String,
+}
+
+impl Click {
+    pub fn new(id: String) -> Click {
+        Click {
+            id,
+            name: BehaviorType::Click,
+            running: false,
+        }
+    }
+}
+
+impl BehaviorState for Click {
+    fn start(&mut self, _now: f64) {
+        self.running = true;
+    }
+
+    fn stop(&mut self, _now: f64) {
+        self.running = false;
+    }
+
+    fn is_running(&self) -> bool {
+        self.running
+    }
+}
+
+impl Behavior for Click {
+    fn id(&self) -> &String {
+        &self.id
+    }
+
+    fn name(&self) -> BehaviorType {
+        BehaviorType::Click
+    }
+
+    fn execute(
+        &mut self,
+        now: f64,
+        _last_frame: f64,
+        mouse: &Position,
+        _context: &CanvasRenderingContext2d,
+    ) -> Option<SpriteMutation> {
+        log!("Execute Click action! {} / {:?}", now, mouse);
+
+        None
+    }
+}

--- a/src/sprite/behavior/click.rs
+++ b/src/sprite/behavior/click.rs
@@ -1,14 +1,14 @@
 use web_sys::CanvasRenderingContext2d;
 
 use super::base::{Behavior, BehaviorState};
-use crate::log;
-use crate::model::{BehaviorType, Position};
+use crate::model::{BehaviorType, GameInteraction, Position};
 use crate::painter::Painter;
 use crate::sprite::{Sprite, SpriteMutation};
 
 pub struct Click {
     name: BehaviorType,
     running: bool,
+    interaction_active: bool,
 }
 
 impl Click {
@@ -16,6 +16,7 @@ impl Click {
         Click {
             name: BehaviorType::Click,
             running: false,
+            interaction_active: false,
         }
     }
 }
@@ -39,6 +40,20 @@ impl Behavior for Click {
         BehaviorType::Click
     }
 
+    fn get_interaction(&self) -> Option<GameInteraction> {
+        if self.interaction_active {
+            return Some(GameInteraction::SpriteClick(String::from(
+                "TODO CONNECT ID",
+            )));
+        }
+
+        None
+    }
+
+    fn clean_interaction(&mut self) {
+        self.interaction_active = false;
+    }
+
     fn execute(
         &mut self,
         sprite: &Sprite,
@@ -48,10 +63,13 @@ impl Behavior for Click {
         context: &CanvasRenderingContext2d,
     ) -> Option<SpriteMutation> {
         self.stop(now);
-        log!("Execute Click action! {} / {:?}", now, mouse);
 
         let clicked = Painter::in_path(&sprite.outlines, mouse, context);
 
-        Some(SpriteMutation::new(None, None, Some(clicked)))
+        if clicked {
+            self.interaction_active = true;
+        }
+
+        None
     }
 }

--- a/src/sprite/behavior/click.rs
+++ b/src/sprite/behavior/click.rs
@@ -1,14 +1,15 @@
+use derives::{derive_behavior_fields, BaseBehavior};
 use web_sys::CanvasRenderingContext2d;
 
-use super::base::{Behavior, BehaviorState};
+use super::base::Behavior;
 use crate::model::{BehaviorType, Callback, GameInteraction, Position};
 use crate::painter::Painter;
 use crate::sprite::{Sprite, SpriteMutation};
 
+#[derive_behavior_fields("")]
+#[derive(BaseBehavior, Default)]
 pub struct Click {
     name: BehaviorType,
-    running: bool,
-    interaction_active: bool,
     callback: Callback,
 }
 
@@ -17,23 +18,8 @@ impl Click {
         Click {
             callback,
             name: BehaviorType::Click,
-            running: false,
-            interaction_active: false,
+            ..Default::default()
         }
-    }
-}
-
-impl BehaviorState for Click {
-    fn start(&mut self, _now: f64) {
-        self.running = true;
-    }
-
-    fn stop(&mut self, _now: f64) {
-        self.running = false;
-    }
-
-    fn is_running(&self) -> bool {
-        self.running
     }
 }
 

--- a/src/sprite/behavior/click.rs
+++ b/src/sprite/behavior/click.rs
@@ -8,13 +8,11 @@ use crate::sprite::{Sprite, SpriteMutation};
 pub struct Click {
     name: BehaviorType,
     running: bool,
-    id: String,
 }
 
 impl Click {
-    pub fn new(id: String) -> Click {
+    pub fn new() -> Click {
         Click {
-            id,
             name: BehaviorType::Click,
             running: false,
         }
@@ -36,10 +34,6 @@ impl BehaviorState for Click {
 }
 
 impl Behavior for Click {
-    fn id(&self) -> &String {
-        &self.id
-    }
-
     fn name(&self) -> BehaviorType {
         BehaviorType::Click
     }

--- a/src/sprite/behavior/click.rs
+++ b/src/sprite/behavior/click.rs
@@ -9,7 +9,7 @@ pub struct Click {
     name: BehaviorType,
     running: bool,
     interaction_active: bool,
-    callback: Callback
+    callback: Callback,
 }
 
 impl Click {

--- a/src/sprite/behavior/click.rs
+++ b/src/sprite/behavior/click.rs
@@ -1,7 +1,7 @@
 use web_sys::CanvasRenderingContext2d;
 
 use super::base::{Behavior, BehaviorState};
-use crate::model::{BehaviorType, GameInteraction, Position};
+use crate::model::{BehaviorType, Callback, GameInteraction, Position};
 use crate::painter::Painter;
 use crate::sprite::{Sprite, SpriteMutation};
 
@@ -9,11 +9,13 @@ pub struct Click {
     name: BehaviorType,
     running: bool,
     interaction_active: bool,
+    callback: Callback
 }
 
 impl Click {
-    pub fn new() -> Click {
+    pub fn new(callback: Callback) -> Click {
         Click {
+            callback,
             name: BehaviorType::Click,
             running: false,
             interaction_active: false,
@@ -42,9 +44,7 @@ impl Behavior for Click {
 
     fn get_interaction(&self) -> Option<GameInteraction> {
         if self.interaction_active {
-            return Some(GameInteraction::SpriteClick(String::from(
-                "TODO CONNECT ID",
-            )));
+            return Some(GameInteraction::SpriteClick(self.callback));
         }
 
         None

--- a/src/sprite/behavior/click.rs
+++ b/src/sprite/behavior/click.rs
@@ -3,6 +3,7 @@ use web_sys::CanvasRenderingContext2d;
 use super::base::{Behavior, BehaviorState};
 use crate::log;
 use crate::model::{BehaviorType, Position};
+use crate::painter::Painter;
 use crate::sprite::{Sprite, SpriteMutation};
 
 pub struct Click {
@@ -44,10 +45,13 @@ impl Behavior for Click {
         now: f64,
         _last_frame: f64,
         mouse: &Position,
-        _context: &CanvasRenderingContext2d,
+        context: &CanvasRenderingContext2d,
     ) -> Option<SpriteMutation> {
+        self.stop(now);
         log!("Execute Click action! {} / {:?}", now, mouse);
 
-        None
+        let clicked = Painter::in_path(&sprite.outlines, mouse, context);
+
+        Some(SpriteMutation::new(None, None, Some(clicked)))
     }
 }

--- a/src/sprite/behavior/click.rs
+++ b/src/sprite/behavior/click.rs
@@ -3,7 +3,7 @@ use web_sys::CanvasRenderingContext2d;
 use super::base::{Behavior, BehaviorState};
 use crate::log;
 use crate::model::{BehaviorType, Position};
-use crate::sprite::SpriteMutation;
+use crate::sprite::{Sprite, SpriteMutation};
 
 pub struct Click {
     name: BehaviorType,
@@ -46,6 +46,7 @@ impl Behavior for Click {
 
     fn execute(
         &mut self,
+        sprite: &Sprite,
         now: f64,
         _last_frame: f64,
         mouse: &Position,

--- a/src/sprite/behavior/hover.rs
+++ b/src/sprite/behavior/hover.rs
@@ -53,6 +53,6 @@ impl Behavior for Hover {
 
         let hovered = Painter::in_path(&sprite.outlines, mouse, context);
 
-        Some(SpriteMutation::new(None, Some(hovered), None))
+        Some(SpriteMutation::new(None, Some(hovered), None)) // TODO -> Builder pattern
     }
 }

--- a/src/sprite/behavior/hover.rs
+++ b/src/sprite/behavior/hover.rs
@@ -1,7 +1,6 @@
 use web_sys::CanvasRenderingContext2d;
 
 use super::base::{Behavior, BehaviorState};
-use crate::log;
 use crate::model::{BehaviorType, Position};
 use crate::painter::Painter;
 use crate::sprite::{Sprite, SpriteMutation};
@@ -47,12 +46,10 @@ impl Behavior for Hover {
         mouse: &Position,
         context: &CanvasRenderingContext2d,
     ) -> Option<SpriteMutation> {
-        log!("Execute Hover aciton! {} / {:?}", sprite.id, mouse);
-
         self.stop(now);
 
         let hovered = Painter::in_path(&sprite.outlines, mouse, context);
 
-        Some(SpriteMutation::new(None, Some(hovered), None)) // TODO -> Builder pattern
+        Some(SpriteMutation::new().hovered(hovered))
     }
 }

--- a/src/sprite/behavior/hover.rs
+++ b/src/sprite/behavior/hover.rs
@@ -1,0 +1,65 @@
+use web_sys::CanvasRenderingContext2d;
+
+use super::base::{Behavior, BehaviorState};
+use crate::log;
+use crate::model::{BehaviorType, Position};
+use crate::sprite::SpriteMutation;
+
+pub struct Hover {
+    name: BehaviorType,
+    running: bool,
+    id: String,
+}
+
+impl Hover {
+    pub fn new(id: String) -> Hover {
+        Hover {
+            id,
+            name: BehaviorType::Hover,
+            running: false,
+        }
+    }
+}
+
+impl BehaviorState for Hover {
+    fn start(&mut self, _now: f64) {
+        self.running = true;
+    }
+
+    fn stop(&mut self, _now: f64) {
+        self.running = false;
+    }
+
+    fn is_running(&self) -> bool {
+        self.running
+    }
+}
+
+impl Behavior for Hover {
+    fn id(&self) -> &String {
+        &self.id
+    }
+
+    fn name(&self) -> BehaviorType {
+        BehaviorType::Hover
+    }
+
+    fn execute(
+        &mut self,
+        now: f64,
+        _last_frame: f64,
+        mouse: &Position,
+        _context: &CanvasRenderingContext2d,
+    ) -> Option<SpriteMutation> {
+        log!("Execute Hover aciton! {} / {:?}", now, mouse);
+
+        Some(SpriteMutation::new(
+            Some(Position {
+                left: 0.0,
+                top: 1.0,
+            }),
+            None,
+            None,
+        ))
+    }
+}

--- a/src/sprite/behavior/hover.rs
+++ b/src/sprite/behavior/hover.rs
@@ -3,7 +3,7 @@ use web_sys::CanvasRenderingContext2d;
 use super::base::{Behavior, BehaviorState};
 use crate::log;
 use crate::model::{BehaviorType, Position};
-use crate::sprite::SpriteMutation;
+use crate::sprite::{Sprite, SpriteMutation};
 
 pub struct Hover {
     name: BehaviorType,
@@ -46,12 +46,15 @@ impl Behavior for Hover {
 
     fn execute(
         &mut self,
+        sprite: &Sprite,
         now: f64,
         _last_frame: f64,
         mouse: &Position,
         _context: &CanvasRenderingContext2d,
     ) -> Option<SpriteMutation> {
-        log!("Execute Hover aciton! {} / {:?}", now, mouse);
+        log!("Execute Hover aciton! {} / {:?}", sprite.id, mouse);
+
+        self.stop(now);
 
         Some(SpriteMutation::new(
             Some(Position {

--- a/src/sprite/behavior/hover.rs
+++ b/src/sprite/behavior/hover.rs
@@ -1,35 +1,23 @@
+use derives::{derive_behavior_fields, BaseBehavior};
 use web_sys::CanvasRenderingContext2d;
 
-use super::base::{Behavior, BehaviorState};
+use super::base::Behavior;
 use crate::model::{BehaviorType, Position};
 use crate::painter::Painter;
 use crate::sprite::{Sprite, SpriteMutation};
 
+#[derive_behavior_fields("")]
+#[derive(BaseBehavior, Default)]
 pub struct Hover {
     name: BehaviorType,
-    running: bool,
 }
 
 impl Hover {
     pub fn new() -> Hover {
         Hover {
             name: BehaviorType::Hover,
-            running: false,
+            ..Default::default()
         }
-    }
-}
-
-impl BehaviorState for Hover {
-    fn start(&mut self, _now: f64) {
-        self.running = true;
-    }
-
-    fn stop(&mut self, _now: f64) {
-        self.running = false;
-    }
-
-    fn is_running(&self) -> bool {
-        self.running
     }
 }
 

--- a/src/sprite/behavior/hover.rs
+++ b/src/sprite/behavior/hover.rs
@@ -3,18 +3,17 @@ use web_sys::CanvasRenderingContext2d;
 use super::base::{Behavior, BehaviorState};
 use crate::log;
 use crate::model::{BehaviorType, Position};
+use crate::painter::Painter;
 use crate::sprite::{Sprite, SpriteMutation};
 
 pub struct Hover {
     name: BehaviorType,
     running: bool,
-    id: String,
 }
 
 impl Hover {
-    pub fn new(id: String) -> Hover {
+    pub fn new() -> Hover {
         Hover {
-            id,
             name: BehaviorType::Hover,
             running: false,
         }
@@ -36,10 +35,6 @@ impl BehaviorState for Hover {
 }
 
 impl Behavior for Hover {
-    fn id(&self) -> &String {
-        &self.id
-    }
-
     fn name(&self) -> BehaviorType {
         BehaviorType::Hover
     }
@@ -50,19 +45,14 @@ impl Behavior for Hover {
         now: f64,
         _last_frame: f64,
         mouse: &Position,
-        _context: &CanvasRenderingContext2d,
+        context: &CanvasRenderingContext2d,
     ) -> Option<SpriteMutation> {
         log!("Execute Hover aciton! {} / {:?}", sprite.id, mouse);
 
         self.stop(now);
 
-        Some(SpriteMutation::new(
-            Some(Position {
-                left: 0.0,
-                top: 1.0,
-            }),
-            None,
-            None,
-        ))
+        let hovered = Painter::in_path(&sprite.outlines, mouse, context);
+
+        Some(SpriteMutation::new(None, Some(hovered), None))
     }
 }

--- a/src/sprite/behavior/mod.rs
+++ b/src/sprite/behavior/mod.rs
@@ -8,8 +8,9 @@ pub use base::Behavior;
 pub use click::Click;
 pub use hover::Hover;
 use web_sys::CanvasRenderingContext2d;
+use crate::log;
 
-use crate::model::{BehaviorData, BehaviorType, GameInteraction, Position};
+use crate::model::{BehaviorData, BehaviorType, Callback, GameInteraction, Position};
 use crate::sprite::{Sprite, SpriteMutation};
 use crate::timers::GameTime;
 
@@ -20,7 +21,7 @@ impl BehaviorManager {
         let behavior_type = BehaviorType::from_string(&data.name);
 
         match behavior_type {
-            BehaviorType::Click => Box::new(Click::new()),
+            BehaviorType::Click => Box::new(Click::new(data.callback.unwrap())),
             BehaviorType::Hover => Box::new(Hover::new()),
         }
     }
@@ -57,15 +58,15 @@ impl BehaviorManager {
         });
     }
 
-    pub fn collect_interactions(sprites: &Sprite) -> Vec<GameInteraction> {
-        let interactions = sprites
+    pub fn collect_interactions(sprite: &Sprite) -> Vec<GameInteraction> {
+        let interactions = sprite
             .mutable_behaviors()
             .iter_mut()
             .map(|behavior| behavior.get_interaction())
             .filter_map(|interaction| interaction)
             .collect();
 
-        sprites.mutable_behaviors().iter_mut().for_each(|behavior| {
+        sprite.mutable_behaviors().iter_mut().for_each(|behavior| {
             behavior.clean_interaction();
         });
 

--- a/src/sprite/behavior/mod.rs
+++ b/src/sprite/behavior/mod.rs
@@ -1,0 +1,42 @@
+mod base;
+mod click;
+mod hover;
+
+pub use base::Behavior;
+pub use click::Click;
+pub use hover::Hover;
+use web_sys::CanvasRenderingContext2d;
+
+use crate::log;
+use crate::model::Position;
+use crate::sprite::{Sprite, SpriteMutation};
+
+pub struct BehaviorManager;
+
+impl BehaviorManager {
+    pub fn create(id: &str, name: &str) -> Box<dyn Behavior> {
+        let behavior_id = String::from(id);
+
+        match name {
+            "Click" => Box::new(Click::new(behavior_id)),
+            _ => Box::new(Hover::new(behavior_id)),
+        }
+    }
+
+    pub fn run_sprite_behaviours(
+        sprite: &mut Sprite,
+        now: f64,
+        last_frame: f64,
+        position: &Position,
+        context: &CanvasRenderingContext2d,
+    ) -> Vec<SpriteMutation> {
+        let behaviors: &mut Vec<Box<dyn Behavior>> = sprite.behaviors.as_mut();
+
+        behaviors
+            .iter_mut()
+            .filter(|behavior| behavior.is_running())
+            .map(|behavior| behavior.execute(now, last_frame, position, context))
+            .filter_map(|mutation| mutation)
+            .collect()
+    }
+}

--- a/src/sprite/behavior/mod.rs
+++ b/src/sprite/behavior/mod.rs
@@ -35,8 +35,7 @@ impl BehaviorManager {
         context: &CanvasRenderingContext2d,
     ) -> Vec<SpriteMutation> {
         sprite
-            .behaviors
-            .borrow_mut()
+            .mutable_behaviors()
             .iter_mut()
             .filter(|behavior| behavior.is_running())
             .map(|behavior| {
@@ -54,8 +53,7 @@ impl BehaviorManager {
     ) {
         sprites.for_each(|sprite| {
             sprite
-                .behaviors
-                .borrow_mut()
+                .mutable_behaviors()
                 .iter_mut()
                 .filter(|behavior| behavior_types.contains(&behavior.name()))
                 .for_each(|behavior| behavior.toggle(should_run, now));

--- a/src/sprite/behavior/mod.rs
+++ b/src/sprite/behavior/mod.rs
@@ -21,7 +21,7 @@ pub struct BehaviorManager;
 impl BehaviorManager {
     pub fn create(data: &BehaviorData) -> Box<dyn Behavior> {
         match data.name.trim() {
-            "Click" => Box::new(Click::new()),
+            "Click" => Box::new(Click::new()), // TODO - BEhaviour enum check
             _ => Box::new(Hover::new()),
         }
     }

--- a/src/sprite/behavior/mod.rs
+++ b/src/sprite/behavior/mod.rs
@@ -8,9 +8,9 @@ pub use base::Behavior;
 pub use click::Click;
 pub use hover::Hover;
 use web_sys::CanvasRenderingContext2d;
-use crate::log;
 
-use crate::model::{BehaviorData, BehaviorType, Callback, GameInteraction, Position};
+
+use crate::model::{BehaviorData, BehaviorType, GameInteraction, Position};
 use crate::sprite::{Sprite, SpriteMutation};
 use crate::timers::GameTime;
 

--- a/src/sprite/behavior/mod.rs
+++ b/src/sprite/behavior/mod.rs
@@ -12,19 +12,17 @@ pub use hover::Hover;
 use web_sys::CanvasRenderingContext2d;
 
 use crate::log;
-use crate::model::{BehaviorType, Position};
+use crate::model::{BehaviorData, BehaviorType, Position};
 use crate::sprite::{Sprite, SpriteMutation};
 use crate::timers::GameTime;
 
 pub struct BehaviorManager;
 
 impl BehaviorManager {
-    pub fn create(id: &str, name: &str) -> Box<dyn Behavior> {
-        let behavior_id = String::from(id);
-
-        match name {
-            "Click" => Box::new(Click::new(behavior_id)),
-            _ => Box::new(Hover::new(behavior_id)),
+    pub fn create(data: &BehaviorData) -> Box<dyn Behavior> {
+        match data.name.trim() {
+            "Click" => Box::new(Click::new()),
+            _ => Box::new(Hover::new()),
         }
     }
 

--- a/src/sprite/behavior/mod.rs
+++ b/src/sprite/behavior/mod.rs
@@ -9,7 +9,6 @@ pub use click::Click;
 pub use hover::Hover;
 use web_sys::CanvasRenderingContext2d;
 
-
 use crate::model::{BehaviorData, BehaviorType, GameInteraction, Position};
 use crate::sprite::{Sprite, SpriteMutation};
 use crate::timers::GameTime;

--- a/src/sprite/mod.rs
+++ b/src/sprite/mod.rs
@@ -1,5 +1,9 @@
 mod base;
+mod behavior;
+mod model;
 mod outline;
 
 pub use base::{DrawingState, Sprite};
+pub use behavior::{BehaviorManager, Hover};
+pub use model::SpriteMutation;
 pub use outline::Outline;

--- a/src/sprite/mod.rs
+++ b/src/sprite/mod.rs
@@ -1,3 +1,5 @@
 mod base;
+mod outline;
 
 pub use base::{DrawingState, Sprite};
+pub use outline::Outline;

--- a/src/sprite/model.rs
+++ b/src/sprite/model.rs
@@ -3,15 +3,25 @@ use crate::model::Position;
 pub struct SpriteMutation {
     pub position: Option<Position>,
     pub hovered: Option<bool>,
-    pub clicked: Option<bool>,
 }
 
 impl SpriteMutation {
-    pub fn new(position: Option<Position>, hovered: Option<bool>, clicked: Option<bool>) -> Self {
+    pub fn new() -> Self {
         Self {
-            position,
-            hovered,
-            clicked,
+            position: None,
+            hovered: None,
         }
+    }
+
+    pub fn position(mut self, position: Position) -> Self {
+        self.position = Some(position);
+
+        self
+    }
+
+    pub fn hovered(mut self, hovered: bool) -> Self {
+        self.hovered = Some(hovered);
+
+        self
     }
 }

--- a/src/sprite/model.rs
+++ b/src/sprite/model.rs
@@ -1,0 +1,17 @@
+use crate::model::Position;
+
+pub struct SpriteMutation {
+    position: Option<Position>,
+    hovered: Option<bool>,
+    clicked: Option<bool>,
+}
+
+impl SpriteMutation {
+    pub fn new(position: Option<Position>, hovered: Option<bool>, clicked: Option<bool>) -> Self {
+        Self {
+            position,
+            hovered,
+            clicked,
+        }
+    }
+}

--- a/src/sprite/model.rs
+++ b/src/sprite/model.rs
@@ -1,9 +1,9 @@
 use crate::model::Position;
 
 pub struct SpriteMutation {
-    position: Option<Position>,
-    hovered: Option<bool>,
-    clicked: Option<bool>,
+    pub position: Option<Position>,
+    pub hovered: Option<bool>,
+    pub clicked: Option<bool>,
 }
 
 impl SpriteMutation {

--- a/src/sprite/outline/marching_squares.rs
+++ b/src/sprite/outline/marching_squares.rs
@@ -16,30 +16,26 @@ impl MarchingSquares {
         }
     }
 
-    pub fn get(&self, data: &[u8], width: i32, height: i32) -> Vec<Position> {
-        self.get_blob_outline_points(data, width, height)
-    }
-
-    fn get_blob_outline_points(&self, data4: &[u8], width: i32, height: i32) -> Vec<Position> {
+    pub fn get(&self, data4: &[u8], width: i32, height: i32) -> Vec<Position> {
         let size = width * height;
         let mut data: Vec<u8> = vec![0; size as usize];
 
-        let multiplier = 4;
+        let opacity_index = 4; // Data is a JS `Uint8ClampedArray`, each item represented as `r,g,b,a` e.g as 4 cells.
         for i in 0..size {
-            data[i as usize] = data4[(i * multiplier) as usize];
+            data[i as usize] = data4[(i * opacity_index) as usize];
         }
 
-        let starting_point = self.get_first_non_transparent_pixel_top_down(&data, width, height);
+        let starting_point = self.get_first_non_transparent_pixel(&data, width, height);
 
         match starting_point {
             Some(starting_point) => {
-                self.walk_perimeter(&data, width, height, starting_point.0, starting_point.1)
+                self.walk_points(&data, width, height, starting_point.0, starting_point.1)
             }
             None => vec![],
         }
     }
 
-    fn get_first_non_transparent_pixel_top_down(
+    fn get_first_non_transparent_pixel(
         &self,
         data: &[u8],
         width: i32,
@@ -60,7 +56,7 @@ impl MarchingSquares {
         None
     }
 
-    fn walk_perimeter(
+    fn walk_points(
         &self,
         data: &[u8],
         width: i32,

--- a/src/sprite/outline/marching_squares.rs
+++ b/src/sprite/outline/marching_squares.rs
@@ -1,0 +1,173 @@
+use std::cell::Cell;
+use std::rc::Rc;
+
+use crate::model::Position;
+
+pub struct MarchingSquares {
+    state: Rc<Cell<i32>>,
+    offset: Position,
+}
+
+impl MarchingSquares {
+    pub fn new(offset: Position) -> MarchingSquares {
+        MarchingSquares {
+            state: Rc::new(Cell::new(0)),
+            offset,
+        }
+    }
+
+    pub fn get(&self, data: &[u8], width: i32, height: i32) -> Vec<Position> {
+        self.get_blob_outline_points(data, width, height)
+    }
+
+    fn get_blob_outline_points(&self, data4: &[u8], width: i32, height: i32) -> Vec<Position> {
+        let size = width * height;
+        let mut data: Vec<u8> = vec![0; size as usize];
+
+        let multiplier = 4;
+        for i in 0..size {
+            data[i as usize] = data4[(i * multiplier) as usize];
+        }
+
+        let starting_point = self.get_first_non_transparent_pixel_top_down(&data, width, height);
+
+        match starting_point {
+            Some(starting_point) => {
+                self.walk_perimeter(&data, width, height, starting_point.0, starting_point.1)
+            }
+            None => vec![],
+        }
+    }
+
+    fn get_first_non_transparent_pixel_top_down(
+        &self,
+        data: &[u8],
+        width: i32,
+        height: i32,
+    ) -> Option<(i32, i32)> {
+        for h in 0..height {
+            let mut idx = h * width;
+
+            for w in 0..width {
+                if data[idx as usize] > 0 {
+                    return Some((w, h));
+                }
+
+                idx += 1;
+            }
+        }
+
+        None
+    }
+
+    fn walk_perimeter(
+        &self,
+        data: &[u8],
+        width: i32,
+        height: i32,
+        start_w: i32,
+        start_h: i32,
+    ) -> Vec<Position> {
+        let mut point_list: Vec<Position> = vec![];
+        let up = 1;
+        let left = 2;
+        let down = 3;
+        let right = 4;
+        let mut w = start_w;
+        let mut h = start_h;
+
+        loop {
+            if w >= 0 && w < width && h >= 0 && h < height {
+                point_list.push(Position::new(
+                    self.offset.top + h as f64,
+                    self.offset.left + (w - 1) as f64,
+                ));
+            }
+
+            let idx = (h - 1) * width + (w - 1);
+            let next_step = self.step(idx, data, width);
+
+            if next_step == up {
+                h -= 1;
+            } else if next_step == left {
+                w -= 1;
+            } else if next_step == down {
+                h += 1;
+            } else if next_step == right {
+                w += 1;
+            }
+
+            if w == start_w && h == start_h {
+                break;
+            }
+        }
+
+        point_list.push(Position::new(
+            self.offset.top + h as f64,
+            self.offset.left + w as f64,
+        ));
+
+        point_list
+    }
+
+    fn get_pixel(&self, data: &[u8], idx: i32) -> u8 {
+        match data.get(idx as usize) {
+            Some(value) => *value,
+            None => 0,
+        }
+    }
+
+    fn step(&self, idx: i32, data: &[u8], width: i32) -> i32 {
+        let up_left = 0 < self.get_pixel(data, idx + 1);
+        let up_right = 0 < self.get_pixel(data, idx + 2);
+        let down_left = 0 < self.get_pixel(data, idx + width + 1);
+        let down_right = 0 < self.get_pixel(data, idx + width + 2);
+        let none = 0;
+        let up = 1;
+        let left = 2;
+        let down = 3;
+        let right = 4;
+        let state_inner = self.state.clone();
+        let mut state = 0;
+
+        if up_left {
+            state |= 1;
+        }
+
+        if up_right {
+            state |= 2;
+        }
+
+        if down_left {
+            state |= 4;
+        }
+
+        if down_right {
+            state |= 8
+        }
+
+        let new_state = match state {
+            1 => up,
+            2 => right,
+            3 => right,
+            4 => left,
+            5 => up,
+            6 if state_inner.get() == up => left,
+            6 => right,
+            7 => right,
+            8 => down,
+            9 if state_inner.get() == right => up,
+            9 => down,
+            10 => down,
+            11 => down,
+            12 => left,
+            13 => up,
+            14 => left,
+            _ => none,
+        };
+
+        state_inner.set(new_state);
+
+        new_state
+    }
+}

--- a/src/sprite/outline/marching_squares.rs
+++ b/src/sprite/outline/marching_squares.rs
@@ -16,7 +16,7 @@ impl MarchingSquares {
         }
     }
 
-    pub fn get(&self, data4: &[u8], width: i32, height: i32) -> Vec<Position> {
+    pub fn data_outlines(&self, data4: &[u8], width: i32, height: i32) -> Vec<Position> {
         let size = width * height;
         let mut data: Vec<u8> = vec![0; size as usize];
 

--- a/src/sprite/outline/mod.rs
+++ b/src/sprite/outline/mod.rs
@@ -12,6 +12,7 @@ use crate::sprite::{DrawingState, Sprite};
 pub struct Outline;
 
 impl Outline {
+    /// Calculates a given Sprite entity outlines points (min of 4 points).
     pub fn get_outlines(sprite: &Sprite, exact: bool) -> Vec<Position> {
         let (cell, position) = DrawingState::get(sprite);
         let scale = sprite.drawing_state.scale;
@@ -63,7 +64,7 @@ impl Outline {
             .unwrap();
 
         // Apply MarchingSquares upon image data as blob, to leave only it's outline
-        MarchingSquares::new(offset.clone()).get(
+        MarchingSquares::new(offset.clone()).data_outlines(
             &image_data.data(),
             width as i32,
             height as i32,

--- a/src/sprite/outline/mod.rs
+++ b/src/sprite/outline/mod.rs
@@ -12,17 +12,13 @@ use crate::sprite::{DrawingState, Sprite};
 pub struct Outline;
 
 impl Outline {
-    pub fn get_outlines(sprite: &Sprite, exact: Option<bool>) -> Vec<Position> {
+    pub fn get_outlines(sprite: &Sprite, exact: bool) -> Vec<Position> {
         let (cell, position) = DrawingState::get(sprite);
         let scale = sprite.drawing_state.scale;
-        let exact_outlines = match exact {
-            Some(_e) => true,
-            None => false,
-        };
 
         let size = cell.into();
 
-        if exact_outlines {
+        if exact {
             return Outline::get_exact_outlines(&sprite.image, cell, position, size, scale);
         }
 
@@ -55,6 +51,7 @@ impl Outline {
             .upgrade()
             .expect("[Outline] - Cannot get exact outline Image is not available");
 
+        // Get measurements painter for off screen drawings
         let painter = Painter::get_measurements_painter(size);
 
         let image_draw_start = Position::new(0.0, 0.0);
@@ -65,6 +62,7 @@ impl Outline {
             .get_image_data(0.0, 0.0, width, height)
             .unwrap();
 
+        // Apply MarchingSquares upon image data as blob, to leave only it's outline
         MarchingSquares::new(offset.clone()).get(
             &image_data.data(),
             width as i32,

--- a/src/sprite/outline/mod.rs
+++ b/src/sprite/outline/mod.rs
@@ -1,0 +1,74 @@
+mod marching_squares;
+
+use std::rc::Weak;
+
+use web_sys::HtmlImageElement;
+
+use crate::model::{Position, Size, SpriteCell};
+use crate::painter::Painter;
+use crate::sprite::outline::marching_squares::MarchingSquares;
+use crate::sprite::{DrawingState, Sprite};
+
+pub struct Outline;
+
+impl Outline {
+    pub fn get_outlines(sprite: &Sprite, exact: Option<bool>) -> Vec<Position> {
+        let (cell, position) = DrawingState::get(sprite);
+        let scale = sprite.drawing_state.scale;
+        let exact_outlines = match exact {
+            Some(_e) => true,
+            None => false,
+        };
+
+        let size = cell.into();
+
+        if exact_outlines {
+            return Outline::get_exact_outlines(&sprite.image, cell, position, size, scale);
+        }
+
+        Outline::get_rect_outlines(position, size, scale)
+    }
+
+    pub fn get_rect_outlines(offset: &Position, size: Size, scale: f64) -> Vec<Position> {
+        let scale_left = size.width * scale;
+        let scale_top = size.height * scale;
+
+        vec![
+            *offset,                                                         // Top left
+            Position::new(offset.top, offset.left + scale_left),             // Right top
+            Position::new(offset.top + scale_top, offset.left + scale_left), // Bottom right
+            Position::new(offset.top + scale_top, offset.left),              // Bottom left
+        ]
+    }
+
+    pub fn get_exact_outlines(
+        sprite_image: &Option<Weak<HtmlImageElement>>,
+        cell: &SpriteCell,
+        offset: &Position,
+        size: Size,
+        scale: f64,
+    ) -> Vec<Position> {
+        let Size { width, height } = size;
+        let image_ref = sprite_image
+            .as_ref()
+            .unwrap()
+            .upgrade()
+            .expect("[Outline] - Cannot get exact outline Image is not available");
+
+        let painter = Painter::get_measurements_painter(size);
+
+        let image_draw_start = Position::new(0.0, 0.0);
+        painter.draw_image(&image_ref, &image_draw_start, cell, scale);
+
+        let image_data = painter
+            .context
+            .get_image_data(0.0, 0.0, width, height)
+            .unwrap();
+
+        MarchingSquares::new(offset.clone()).get(
+            &image_data.data(),
+            width as i32,
+            height as i32,
+        )
+    }
+}

--- a/src/sprite/outline/mod.rs
+++ b/src/sprite/outline/mod.rs
@@ -3,6 +3,7 @@ mod marching_squares;
 use std::rc::Weak;
 
 use web_sys::HtmlImageElement;
+use crate::log;
 
 use crate::model::{Position, Size, SpriteCell};
 use crate::painter::Painter;
@@ -14,6 +15,7 @@ pub struct Outline;
 impl Outline {
     /// Calculates a given Sprite entity outlines points (min of 4 points).
     pub fn get_outlines(sprite: &Sprite, exact: bool) -> Vec<Position> {
+        log!("Calculating sprite outlines!");
         let (cell, position) = DrawingState::get(sprite);
         let scale = sprite.drawing_state.scale;
 

--- a/src/sprite/outline/mod.rs
+++ b/src/sprite/outline/mod.rs
@@ -4,7 +4,6 @@ use std::rc::Weak;
 
 use web_sys::HtmlImageElement;
 
-use crate::log;
 use crate::model::{Position, Size, SpriteCell};
 use crate::painter::Painter;
 use crate::sprite::outline::marching_squares::MarchingSquares;
@@ -15,7 +14,6 @@ pub struct Outline;
 impl Outline {
     /// Calculates a given Sprite entity outlines points (min of 4 points).
     pub fn get_outlines(sprite: &Sprite, exact: bool) -> Vec<Position> {
-        log!("Calculating sprite outlines!");
         let (cell, position) = DrawingState::get(sprite);
         let scale = sprite.drawing_state.scale;
 

--- a/src/sprite/outline/mod.rs
+++ b/src/sprite/outline/mod.rs
@@ -3,8 +3,8 @@ mod marching_squares;
 use std::rc::Weak;
 
 use web_sys::HtmlImageElement;
-use crate::log;
 
+use crate::log;
 use crate::model::{Position, Size, SpriteCell};
 use crate::painter::Painter;
 use crate::sprite::outline::marching_squares::MarchingSquares;

--- a/src/timers/game_time.rs
+++ b/src/timers/game_time.rs
@@ -1,8 +1,9 @@
 use crate::timers::base_timer::Timer;
 
 pub struct GameTime {
-    time: f64,
-    last_timestamp: f64,
+    pub time: f64,
+    pub last_timestamp: f64,
+
     timer: Timer,
 }
 

--- a/src/web_utils.rs
+++ b/src/web_utils.rs
@@ -35,6 +35,7 @@ pub fn create_canvas(width: u32, height: u32, attach_to_body: bool) -> HtmlCanva
 
     canvas.set_width(width);
     canvas.set_height(height);
+    canvas.set_id("game_canvas");
 
     if attach_to_body {
         document().body().unwrap().append_child(&canvas).unwrap();

--- a/src/web_utils.rs
+++ b/src/web_utils.rs
@@ -26,7 +26,7 @@ pub fn request_animation_frame(f: &Closure<dyn FnMut()>) {
         .expect("`requestAnimationFrame` is expected to be found upon `window` API.");
 }
 
-pub fn create_canvas(width: u32, height: u32) -> HtmlCanvasElement {
+pub fn create_canvas(width: u32, height: u32, attach_to_body: bool) -> HtmlCanvasElement {
     let canvas = document()
         .create_element("canvas")
         .unwrap()
@@ -36,7 +36,9 @@ pub fn create_canvas(width: u32, height: u32) -> HtmlCanvasElement {
     canvas.set_width(width);
     canvas.set_height(height);
 
-    document().body().unwrap().append_child(&canvas).unwrap();
+    if attach_to_body {
+        document().body().unwrap().append_child(&canvas).unwrap();
+    }
 
     canvas
 }


### PR DESCRIPTION
**Main changes**
- `Behaviors` added to `Sprite` entity, as a `RefCell` which consumed as mutable or not at runtime. Each behavior can return a `SpriteMutation` which will be applied on the `Sprite` itself upon each `run` execution.
- `Behaviors` also can has an `active_interaction` which marks a `GameInteraction` action needs to be taken. `Game` entity is able to intercept any `GameInteraction` with a given payload according to the `type`.
- Adding `derived` internal crate, For now solely implements `Behavior` related:
    * `dervie_behavior_fields` Attribute macro for common fields.
    * `BaseBehavior` procedural macro for `BehaviorState` implementations.
- Add the ability to calculate `Sprite` outlines ( Will be used for `hover`/`click` behaviors to in order to detect rather a given point is within an outline polygon of a given sprite. The basic calculation goes with `rect` size for a regular square-shaped image + and `exact` option to measure the exact outlines depends on the `Sprite` itself (using `MarchingSquares` ).

**Side effects**
- Adding `Painter` ability to measure stuff on offscreen canvas ( Usually for extracting `imageData` from canvas element ).
- Move `sclae` property from `Sprite` to its `DrawingState`.
- General cleanup.