### PR TITLE
Sprite Text's overlays

### DIFF
--- a/assets/json/interface-data.json
+++ b/assets/json/interface-data.json
@@ -42,7 +42,12 @@
   },
   "SelectorWoodSign1": {
     "constructor": "Sprite",
-    "position": [{ "left": 20, "top": -8 }]
+    "position": [{ "left": 20, "top": -8 }],
+    "text_overlay": {
+      "text": "Playa Name",
+      "size": 24,
+      "offset": { "left": 0, "top":  32 }
+    }
   },
   "SelectorWoodSign2": {
     "constructor": "Sprite",

--- a/assets/json/interface-data.json
+++ b/assets/json/interface-data.json
@@ -46,7 +46,7 @@
     "text_overlay": {
       "text": "Playa Name",
       "size": 24,
-      "offset": { "left": 0, "top":  32 }
+      "offset": { "left": 0, "top":  34 }
     }
   },
   "SelectorWoodSign2": {

--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta content="text/html;charset=utf-8" http-equiv="Content-Type" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-
+  <link href="https://fonts.googleapis.com/css?family=Kavivanar" rel="stylesheet" />
   <title>Plants V.S Zombies</title>
 
   <style>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ mod constants;
 mod engine;
 mod fps;
 mod game;
+mod location_builder;
 mod model;
 mod painter;
 mod resource_loader;

--- a/src/location_builder.rs
+++ b/src/location_builder.rs
@@ -1,0 +1,17 @@
+use crate::model::{Position, Size};
+use crate::sprite::Sprite;
+
+pub struct LocationBuilder;
+
+impl LocationBuilder {
+    pub fn place_at_center(sprite: &Sprite, item_dimensions: Size) -> Position {
+        let target_dimensions = sprite.dimensions();
+
+        let center_x =
+            target_dimensions.left + (target_dimensions.width - item_dimensions.width) / 2.0;
+        let center_y =
+            target_dimensions.top + (target_dimensions.height - item_dimensions.height) / 2.0;
+
+        Position::new(center_y, center_x)
+    }
+}

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
 use serde_derive::Deserialize;
-use web_sys::MouseEvent;
+use web_sys::{MouseEvent, TextMetrics};
 
 #[derive(Debug, Default)]
 pub struct GameState {
@@ -69,6 +69,7 @@ pub struct SpriteData {
     pub scale: f64,
     pub exact_outlines: bool,
     pub behaviors: Vec<BehaviorData>,
+    pub text_overlay: Option<TextOverlayData>,
 }
 
 impl Default for SpriteData {
@@ -79,6 +80,7 @@ impl Default for SpriteData {
             scale: 1.0,
             exact_outlines: false,
             behaviors: vec![],
+            text_overlay: None,
         }
     }
 }
@@ -117,6 +119,14 @@ pub struct BehaviorData {
     pub max_cycles: Option<usize>,
 }
 
+#[derive(Debug, Default, Clone, Deserialize)]
+#[serde(default)]
+pub struct TextOverlayData {
+    pub text: String,
+    pub size: usize,
+    pub offset: Option<Position>,
+}
+
 #[derive(Debug, Default, PartialEq, Clone, Copy, Deserialize)]
 pub struct Position {
     pub left: f64,
@@ -142,12 +152,27 @@ pub struct Size {
     pub height: f64,
 }
 
+impl Size {
+    pub fn new(width: f64, height: f64) -> Self {
+        Size { width, height }
+    }
+}
+
 impl From<&SpriteCell> for Size {
     fn from(cell: &SpriteCell) -> Size {
         Size {
             width: cell.width,
             height: cell.height,
         }
+    }
+}
+
+impl From<TextMetrics> for Size {
+    fn from(text_metrics: TextMetrics) -> Self {
+        Size::new(
+            text_metrics.width(),
+            text_metrics.font_bounding_box_descent(),
+        )
     }
 }
 

--- a/src/painter.rs
+++ b/src/painter.rs
@@ -4,7 +4,7 @@ use web_sys::{CanvasRenderingContext2d, HtmlCanvasElement, HtmlImageElement};
 
 use crate::constants::{CANVAS_HEIGHT, CANVAS_HEIGHT_F64, CANVAS_WIDTH, CANVAS_WIDTH_F64};
 use crate::model::{Position, Size, SpriteCell};
-use crate::sprite::{DrawingState, Sprite};
+use crate::sprite::{DrawingState, Sprite, TextOverlay};
 use crate::web_utils::{create_canvas, get_canvas_context};
 
 pub struct Painter {
@@ -42,7 +42,9 @@ impl Painter {
             );
         }
 
-        // TODO TextSprite case
+        if let Some(text_overlay) = &sprite.text_overlay {
+            self.draw_text_overlay(text_overlay);
+        }
     }
 
     pub fn draw_image(
@@ -65,6 +67,28 @@ impl Painter {
                 cell.height * scale,
             )
             .unwrap();
+    }
+
+    pub fn draw_text_overlay(&self, text_overlay: &TextOverlay) {
+        self.context.save();
+
+        let font_size = format!("{}px Kavivanar", text_overlay.size);
+
+        self.context.set_font(&font_size);
+        self.context.set_text_baseline("top");
+
+        let position = &text_overlay.position.unwrap();
+        let offset = &text_overlay.offset.unwrap_or(Position::default());
+
+        self.context
+            .fill_text(
+                &text_overlay.text,
+                position.left + offset.left,
+                position.top + offset.top,
+            )
+            .unwrap();
+
+        self.context.restore();
     }
 
     pub fn in_path(

--- a/src/painter.rs
+++ b/src/painter.rs
@@ -1,6 +1,6 @@
 use std::rc::Rc;
 
-use web_sys::{CanvasRenderingContext2d, HtmlCanvasElement, HtmlImageElement};
+use web_sys::{CanvasRenderingContext2d, HtmlCanvasElement, HtmlImageElement, TextMetrics};
 
 use crate::constants::{CANVAS_HEIGHT, CANVAS_HEIGHT_F64, CANVAS_WIDTH, CANVAS_WIDTH_F64};
 use crate::model::{Position, Size, SpriteCell};
@@ -71,11 +71,7 @@ impl Painter {
 
     pub fn draw_text_overlay(&self, text_overlay: &TextOverlay) {
         self.context.save();
-
-        let font_size = format!("{}px Kavivanar", text_overlay.size);
-
-        self.context.set_font(&font_size);
-        self.context.set_text_baseline("top");
+        self.set_text_styles(text_overlay.size);
 
         let position = &text_overlay.position.unwrap();
         let offset = &text_overlay.offset.unwrap_or(Position::default());
@@ -89,6 +85,17 @@ impl Painter {
             .unwrap();
 
         self.context.restore();
+    }
+
+    pub fn measure_text(text: &str, size: usize) -> Size {
+        let measure_painter = Painter::get_measurements_painter(Size::new(200.0, 200.0));
+
+        measure_painter.set_text_styles(size);
+
+        let text_metrics: TextMetrics = measure_painter.context.measure_text(&text).unwrap();
+        let text_size: Size = text_metrics.into();
+
+        text_size
     }
 
     pub fn in_path(
@@ -120,6 +127,14 @@ impl Painter {
 
         // Check rather if point is within that shape.
         context.is_point_in_path_with_f64(point.left, point.top)
+    }
+
+    pub fn set_text_styles(&self, size: usize) {
+        let font_size = format!("{}px Kavivanar", size);
+
+        self.context.set_font(&font_size);
+        self.context.set_fill_style(&"white".into());
+        self.context.set_text_baseline("top");
     }
 
     pub fn get_measurements_painter(size: Size) -> Painter {

--- a/src/sprite/base.rs
+++ b/src/sprite/base.rs
@@ -5,10 +5,11 @@ use js_sys::Math;
 use web_sys::HtmlImageElement;
 
 use crate::log;
-use crate::model::{BehaviorData, Position, SpriteCell, SpriteData};
+use crate::model::{BehaviorData, Position, SpriteCell, SpriteData, TextOverlayData};
 use crate::resource_loader::{Resource, ResourceKind, Resources};
 use crate::sprite::behavior::{Behavior, BehaviorManager};
 use crate::sprite::drawing_state::DrawingState;
+use crate::sprite::text_overlay::TextOverlay;
 use crate::sprite::{Outline, SpriteMutation};
 
 pub struct Sprite {
@@ -20,6 +21,7 @@ pub struct Sprite {
     pub behaviors: RefCell<Vec<Box<dyn Behavior>>>,
     pub image: Option<Weak<HtmlImageElement>>,
     pub drawing_state: DrawingState,
+    pub text_overlay: Option<TextOverlay>,
 }
 
 impl Sprite {
@@ -32,6 +34,7 @@ impl Sprite {
         scale: f64,
         behaviors: &Vec<BehaviorData>,
         exact_outlines: bool,
+        text_overlay_data: &Option<TextOverlayData>,
     ) -> Sprite {
         let sprite_behaviors = RefCell::new(
             behaviors
@@ -49,6 +52,16 @@ impl Sprite {
             drawing_state: DrawingState::new(cells, scale),
             outlines: vec![],
             behaviors: sprite_behaviors,
+            text_overlay: None,
+        };
+
+        sprite.text_overlay = match text_overlay_data {
+            Some(data) => Some(TextOverlay::new(
+                data,
+                sprite.drawing_state.cells.get(0).unwrap(),
+                &sprite.position,
+            )),
+            None => None,
         };
 
         sprite.outlines = Outline::get_outlines(&sprite, exact_outlines);
@@ -81,6 +94,7 @@ impl Sprite {
             scale,
             behaviors,
             exact_outlines,
+            text_overlay,
             ..
         } = data;
 
@@ -98,6 +112,7 @@ impl Sprite {
                     scale,
                     &behaviors,
                     exact_outlines,
+                    &text_overlay,
                 )
             })
             .collect()

--- a/src/sprite/base.rs
+++ b/src/sprite/base.rs
@@ -56,17 +56,24 @@ impl Sprite {
         };
 
         sprite.text_overlay = match text_overlay_data {
-            Some(data) => Some(TextOverlay::new(
-                data,
-                sprite.drawing_state.cells.get(0).unwrap(),
-                &sprite.position,
-            )),
+            Some(data) => Some(TextOverlay::new(data, &sprite)),
             None => None,
         };
 
         sprite.outlines = Outline::get_outlines(&sprite, exact_outlines);
 
         sprite
+    }
+
+    pub fn dimensions(&self) -> SpriteCell {
+        let active_cell = DrawingState::get_active_cell(&self);
+
+        return SpriteCell {
+            left: self.position.left,
+            top: self.position.top,
+            width: active_cell.width,
+            height: active_cell.height,
+        };
     }
 
     pub fn create_sprites(

--- a/src/sprite/mod.rs
+++ b/src/sprite/mod.rs
@@ -3,9 +3,11 @@ mod behavior;
 mod drawing_state;
 mod model;
 mod outline;
+mod text_overlay;
 
 pub use base::Sprite;
 pub use behavior::{BehaviorManager, Hover};
 pub use drawing_state::DrawingState;
 pub use model::SpriteMutation;
 pub use outline::Outline;
+pub use text_overlay::TextOverlay;

--- a/src/sprite/text_overlay.rs
+++ b/src/sprite/text_overlay.rs
@@ -1,0 +1,51 @@
+use web_sys::TextMetrics;
+
+use crate::log;
+use crate::model::{Position, Size, SpriteCell, TextOverlayData};
+use crate::painter::Painter;
+
+#[derive(Debug)]
+pub struct TextOverlay {
+    pub offset: Option<Position>,
+    pub text: String,
+    pub size: usize,
+    pub position: Option<Position>,
+}
+
+impl TextOverlay {
+    pub fn new(data: &TextOverlayData, source_cell: &SpriteCell, source_position: &Position) -> Self {
+        let mut overlay = TextOverlay {
+            text: data.text.clone(),
+            size: data.size,
+            offset: data.offset,
+            position: None,
+        };
+
+        overlay.calculate_text_position(source_cell, source_position);
+
+        overlay
+    }
+
+    fn calculate_text_position(&mut self, source_cell: &SpriteCell, source_position: &Position) {
+        // Measure current text by it's size, extract a rect of it
+        let measure_painter = Painter::get_measurements_painter(Size::new(200.0, 200.0));
+
+        let font_size = format!("{}px Kavivanar", self.size);
+
+        measure_painter.context.set_font(&font_size);
+        measure_painter.context.set_text_baseline("top");
+
+        log!("Cell size {:?}", source_cell);
+        let text_metrics: TextMetrics = measure_painter.context.measure_text(&self.text).unwrap();
+        let text_size: Size = text_metrics.into();
+        log!("Text Size{} / {}", text_size.height, text_size.width);
+
+        // Position current Text rect within source cell.
+        let center_x = source_position.left + (source_cell.width - text_size.width) / 2.0;
+        let center_y = source_position.top + (source_cell.height - text_size.height) / 2.0;
+
+        self.position = Some(Position::new(center_y, center_x));
+
+        log!("Final position at {}/{}", center_x, center_y)
+    }
+}

--- a/src/sprite/text_overlay.rs
+++ b/src/sprite/text_overlay.rs
@@ -1,8 +1,8 @@
-use web_sys::TextMetrics;
 
-use crate::log;
-use crate::model::{Position, Size, SpriteCell, TextOverlayData};
+use crate::location_builder::LocationBuilder;
+use crate::model::{Position, TextOverlayData};
 use crate::painter::Painter;
+use crate::sprite::Sprite;
 
 #[derive(Debug)]
 pub struct TextOverlay {
@@ -13,7 +13,7 @@ pub struct TextOverlay {
 }
 
 impl TextOverlay {
-    pub fn new(data: &TextOverlayData, source_cell: &SpriteCell, source_position: &Position) -> Self {
+    pub fn new(data: &TextOverlayData, source_sprite: &Sprite) -> Self {
         let mut overlay = TextOverlay {
             text: data.text.clone(),
             size: data.size,
@@ -21,31 +21,16 @@ impl TextOverlay {
             position: None,
         };
 
-        overlay.calculate_text_position(source_cell, source_position);
+        overlay.calculate_text_position(source_sprite);
 
         overlay
     }
 
-    fn calculate_text_position(&mut self, source_cell: &SpriteCell, source_position: &Position) {
+    fn calculate_text_position(&mut self, source_sprite: &Sprite) {
         // Measure current text by it's size, extract a rect of it
-        let measure_painter = Painter::get_measurements_painter(Size::new(200.0, 200.0));
+        let text_size = Painter::measure_text(&self.text, self.size);
 
-        let font_size = format!("{}px Kavivanar", self.size);
-
-        measure_painter.context.set_font(&font_size);
-        measure_painter.context.set_text_baseline("top");
-
-        log!("Cell size {:?}", source_cell);
-        let text_metrics: TextMetrics = measure_painter.context.measure_text(&self.text).unwrap();
-        let text_size: Size = text_metrics.into();
-        log!("Text Size{} / {}", text_size.height, text_size.width);
-
-        // Position current Text rect within source cell.
-        let center_x = source_position.left + (source_cell.width - text_size.width) / 2.0;
-        let center_y = source_position.top + (source_cell.height - text_size.height) / 2.0;
-
-        self.position = Some(Position::new(center_y, center_x));
-
-        log!("Final position at {}/{}", center_x, center_y)
+        // Placing text at the center of the given source sprite.
+        self.position = Some(LocationBuilder::place_at_center(source_sprite, text_size));
     }
 }


### PR DESCRIPTION
**Main changes**
- Adds the ability to place a `Text` on a given `Sprite` represented via a `TextOverlay` struct which defines the text.
- Upon `Sprite` draw cycle, Painter now check if it should pain any `TextOverlay` upon the sprite.
- If so it places it at the center of it (After measuring the text size itself wished to be painted).

**Side effects**
- Added a `dimensions` getter for `Sprite` to represent it's given game inter dimensions.
- Adding `LocationBuilder` to own location/position related logic.