### PR TITLE
Battle Scene - Choose plants + Battle enter

### DIFF
--- a/assets/json/interface-cell.json
+++ b/assets/json/interface-cell.json
@@ -18,7 +18,10 @@
   "SeedChooserBackground": [
     { "left": 498, "top": 1200, "width": 465, "height": 554 }
   ],
-  "SelectCardButton": [
+  "OkButton": [
+    { "left": 1083, "top": 1859, "width": 65, "height": 35 }
+  ],
+  "ResetButton": [
     { "left": 1083, "top": 1859, "width": 65, "height": 35 }
   ],
   "SelectorAdventureButton": [
@@ -64,7 +67,7 @@
   ],
   "Shovel": [{ "left": 1623, "top": 1520, "width": 77, "height": 55 }],
   "ShovelBack": [{ "left": 1012, "top": 1859, "width": 71, "height": 35 }],
-  "SunBack": [{ "left": 350, "top": 1639, "width": 123, "height": 34 }],
+  "SunScore": [{ "left": 350, "top": 1639, "width": 123, "height": 34 }],
   "Sun": [
     { "left": 1702, "top": 1283, "width": 79, "height": 79 },
     { "left": 1400, "top": 409, "width": 79, "height": 79 },

--- a/assets/json/interface-cell.json
+++ b/assets/json/interface-cell.json
@@ -1,5 +1,5 @@
 {
-  "Background1": [{ "left": 0, "top": 0, "width": 1400, "height": 600 }],
+  "BattleBackground": [{ "left": 0, "top": 0, "width": 1400, "height": 600 }],
   "Button": [{ "left": 350, "top": 1673, "width": 113, "height": 41 }],
   "FinalWave": [{ "left": 1618, "top": 1820, "width": 252, "height": 71 }],
   "FlagMeterEmpty": [{ "left": 0, "top": 1860, "width": 157, "height": 21 }],

--- a/assets/json/interface-cell.json
+++ b/assets/json/interface-cell.json
@@ -1,6 +1,6 @@
 {
   "BattleBackground": [{ "left": 0, "top": 0, "width": 1400, "height": 600 }],
-  "Button": [{ "left": 350, "top": 1673, "width": 113, "height": 41 }],
+  "BackButton": [{ "left": 350, "top": 1673, "width": 113, "height": 41 }],
   "FinalWave": [{ "left": 1618, "top": 1820, "width": 252, "height": 71 }],
   "FlagMeterEmpty": [{ "left": 0, "top": 1860, "width": 157, "height": 21 }],
   "FlagMeterFull": [{ "left": 157, "top": 1860, "width": 157, "height": 21 }],

--- a/assets/json/interface-data.json
+++ b/assets/json/interface-data.json
@@ -138,15 +138,33 @@
       "location_type": "Top"
     }
   },
-  "SelectCardButton": {
+  "ResetButton": {
     "constructor": "Sprite",
     "position": [
-      { "left": 265, "top": 495 },
+      { "left": 265, "top": 495 }
+    ],
+    "behaviors": [{ "name": "Click",
+      "callback": "ResetPlantsChoose"
+    }],
+    "text_overlay": {
+      "text": "Reset",
+      "size": 20
+    }
+  },
+  "OkButton": {
+    "constructor": "Sprite",
+    "position": [
       { "left": 340, "top": 495 }
     ],
-    "behaviors": [{ "name": "Click" }]
+    "behaviors": [{ "name": "Click",
+      "callback": "StartBattle"
+    }],
+    "text_overlay": {
+      "text": "Start",
+      "size": 20
+    }
   },
-  "SunBack": {
+  "SunScore": {
     "constructor": "Sprite",
     "position": [{ "left": 100, "top": 0 }],
     "order": 4,

--- a/assets/json/interface-data.json
+++ b/assets/json/interface-data.json
@@ -58,11 +58,10 @@
     "cells": [{ "left": 0, "top": 0, "width": 92, "height": 40 }],
     "position": [{ "left": 34, "top": 179 }]
   },
-  "Background1": {
+  "BattleBackground": {
     "constructor": "Sprite",
     "position": [{ "left": 0, "top": 0 }],
-    "behaviors": [{ "name": "Scroll", "distance": 385, "rate": 350 }],
-    "offset": { "left": 115, "top": 0 },
+    "draw_offset": { "left": 115, "top": 0 },
     "order": 0
   },
   "Sun": {

--- a/assets/json/interface-data.json
+++ b/assets/json/interface-data.json
@@ -67,7 +67,7 @@
         "name": "Scroll",
         "callback": "ShowPlantsChooser",
         "distance": 335,
-        "duration": 15
+        "duration": 12
       }
     ],
     "order": 0
@@ -82,7 +82,7 @@
     ],
     "order": 3
   },
-  "Button": {
+  "BackButton": {
     "constructor": "Sprite",
     "position": [{ "left": 787, "top": 0 }],
     "behaviors": [{ "name": "Click", "callback": "BackHome" }],
@@ -130,7 +130,13 @@
   },
   "SeedChooserBackground": {
     "constructor": "Sprite",
-    "position": [{ "left": 100, "top": 0 }]
+    "position": [{ "left": 100, "top": 0 }],
+    "text_overlay": {
+      "text": "Choose your Plants",
+      "size": 20,
+      "offset": { "left": 0, "top":  8 },
+      "location_type": "Top"
+    }
   },
   "SelectCardButton": {
     "constructor": "Sprite",

--- a/assets/json/interface-data.json
+++ b/assets/json/interface-data.json
@@ -62,6 +62,14 @@
     "constructor": "Sprite",
     "position": [{ "left": 0, "top": 0 }],
     "draw_offset": { "left": 115, "top": 0 },
+    "behaviors": [
+      {
+        "name": "Scroll",
+        "callback": "ShowPlantsChooser",
+        "distance": 335,
+        "duration": 15
+      }
+    ],
     "order": 0
   },
   "Sun": {

--- a/assets/json/interface-data.json
+++ b/assets/json/interface-data.json
@@ -77,7 +77,15 @@
   "Button": {
     "constructor": "Sprite",
     "position": [{ "left": 787, "top": 0 }],
-    "behaviors": [{ "name": "Click" }],
+    "behaviors": [{ "name": "Click", "callback": "BackHome" }],
+    "text_overlay": {
+      "text": "Back",
+      "size": 24,
+      "offset": {
+        "left": 0,
+        "top": 4
+      }
+    },
     "order": 4
   },
   "ShovelBack": {

--- a/assets/json/interface-data.json
+++ b/assets/json/interface-data.json
@@ -67,7 +67,7 @@
         "name": "Scroll",
         "callback": "ShowPlantsChooser",
         "distance": 335,
-        "duration": 12
+        "duration": 18
       }
     ],
     "order": 0
@@ -157,7 +157,7 @@
       { "left": 340, "top": 495 }
     ],
     "behaviors": [{ "name": "Click",
-      "callback": "StartBattle"
+      "callback": "EnterBattleAnimation"
     }],
     "text_overlay": {
       "text": "Start",

--- a/assets/json/level-data.json
+++ b/assets/json/level-data.json
@@ -3,7 +3,7 @@
     "name": "1-1",
     "flag_num": 3,
     "scenes": [
-      "Background1",
+      "BattleBackground",
       "ShovelBack",
       "Shovel",
       "Button",

--- a/src/game.rs
+++ b/src/game.rs
@@ -5,7 +5,7 @@ use crate::log;
 use crate::model::{BehaviorType, Callback, GameInteraction, GameMouseEvent, GameState, Position};
 use crate::painter::Painter;
 use crate::resource_loader::Resources;
-use crate::scene::{BattleScene, HomeScene};
+use crate::scene::{BattleScene, HomeScene, PlantsChooser};
 use crate::sprite::{BehaviorManager, Sprite};
 use crate::timers::GameTime;
 
@@ -119,7 +119,9 @@ impl Game {
             Callback::ShowZombieHand => self.show_zombie_hand_animation(),
             Callback::StartLevel => self.start_level_scene(),
             Callback::BackHome => self.start_home_scene(),
-            Callback::ShowPlantsChooser => self.show_plans_chooser(),
+            Callback::ShowPlantsChooser => self.show_plants_chooser(),
+            Callback::ResetPlantsChoose => self.reset_plants_choose(),
+            Callback::StartBattle => self.start_battle_scene(),
         }
     }
 
@@ -137,15 +139,23 @@ impl Game {
     fn start_level_scene(&mut self) {
         self.reset_state();
 
-        BattleScene::start(self);
+        BattleScene::prepare(self);
     }
 
     pub fn show_zombie_hand_animation(&mut self) {
         HomeScene::show_zombie_hand(self);
     }
 
-    pub fn show_plans_chooser(&mut self) {
-        BattleScene::show_plants_chooser(self);
+    pub fn show_plants_chooser(&mut self) {
+        PlantsChooser::show(self);
+    }
+
+    pub fn reset_plants_choose(&mut self) {
+        log!("Game scene - Reset PlantsChooser");
+    }
+
+    pub fn start_battle_scene(&mut self) {
+        log!("Game scene - Start Battle");
     }
 
     // Game State Mutations //
@@ -159,6 +169,12 @@ impl Game {
         self.sprites.append(sprites);
 
         self.sprites.sort_by(|a, b| a.order.cmp(&b.order));
+    }
+
+    pub fn add_sprite(&mut self, sprite: Sprite) {
+        let mut sprites = vec![sprite];
+
+        self.add_sprites(sprites.as_mut());
     }
 
     // Getters //

--- a/src/game.rs
+++ b/src/game.rs
@@ -5,7 +5,7 @@ use crate::log;
 use crate::model::{BehaviorType, Callback, GameInteraction, GameMouseEvent, GameState, Position};
 use crate::painter::Painter;
 use crate::resource_loader::Resources;
-use crate::scene::HomeScene;
+use crate::scene::{BattleScene, HomeScene};
 use crate::sprite::{BehaviorManager, Sprite};
 use crate::timers::GameTime;
 
@@ -109,12 +109,12 @@ impl Game {
         game_interactions
             .iter()
             .for_each(|interaction| match interaction {
-                GameInteraction::SpriteClick(callback) => self.on_sprite_click(callback),
-                GameInteraction::AnimationCallback(callback) => self.on_sprite_click(callback),
+                GameInteraction::SpriteClick(callback) => self.interaction_callback(callback),
+                GameInteraction::AnimationCallback(callback) => self.interaction_callback(callback),
             });
     }
 
-    pub fn on_sprite_click(&mut self, callback: &Callback) {
+    pub fn interaction_callback(&mut self, callback: &Callback) {
         match callback {
             Callback::ShowZombieHand => self.show_zombie_hand_animation(),
             Callback::StartLevel => self.start_level_scene(),
@@ -128,11 +128,14 @@ impl Game {
 
     fn start_home_scene(&mut self) {
         self.reset_state();
+
         HomeScene::start(self);
     }
 
     fn start_level_scene(&mut self) {
-        log!("[Game Controller] Starting Level Scene!!");
+        self.reset_state();
+
+        BattleScene::choose_plants(self);
     }
 
     pub fn show_zombie_hand_animation(&mut self) {

--- a/src/game.rs
+++ b/src/game.rs
@@ -118,6 +118,7 @@ impl Game {
         match callback {
             Callback::ShowZombieHand => self.show_zombie_hand_animation(),
             Callback::StartLevel => self.start_level_scene(),
+            Callback::BackHome => self.start_home_scene()
         }
     }
 
@@ -135,7 +136,7 @@ impl Game {
     fn start_level_scene(&mut self) {
         self.reset_state();
 
-        BattleScene::choose_plants(self);
+        BattleScene::start(self);
     }
 
     pub fn show_zombie_hand_animation(&mut self) {

--- a/src/game.rs
+++ b/src/game.rs
@@ -118,11 +118,12 @@ impl Game {
         match callback {
             Callback::ShowZombieHand => self.show_zombie_hand_animation(),
             Callback::StartLevel => self.start_level_scene(),
-            Callback::BackHome => self.start_home_scene()
+            Callback::BackHome => self.start_home_scene(),
+            Callback::ShowPlantsChooser => self.show_plans_chooser(),
         }
     }
 
-    // Game Scene //
+    // Scenes //
     pub fn game_over(&mut self) {
         self.painter.clear();
     }
@@ -141,6 +142,10 @@ impl Game {
 
     pub fn show_zombie_hand_animation(&mut self) {
         HomeScene::show_zombie_hand(self);
+    }
+
+    pub fn show_plans_chooser(&mut self) {
+        BattleScene::show_plants_chooser(self);
     }
 
     // Game State Mutations //

--- a/src/game.rs
+++ b/src/game.rs
@@ -15,7 +15,7 @@ pub struct Game {
     pub game_time: GameTime,
     pub mouse_position: Position,
 
-    sprites: Vec<Sprite>,
+    pub sprites: Vec<Sprite>,
     state: GameState,
     fps: Fps,
 }
@@ -94,7 +94,7 @@ impl Game {
     }
 
     pub fn toggle_game_behavior(&mut self, active: bool, types: &[BehaviorType]) {
-        BehaviorManager::toggle_behaviors(self.sprites.iter(), types, active, self.game_time.time)
+        BehaviorManager::toggle_behaviors(&self.sprites, types, active, self.game_time.time)
     }
 
     // Game Actions //
@@ -121,7 +121,8 @@ impl Game {
             Callback::BackHome => self.start_home_scene(),
             Callback::ShowPlantsChooser => self.show_plants_chooser(),
             Callback::ResetPlantsChoose => self.reset_plants_choose(),
-            Callback::StartBattle => self.start_battle_scene(),
+            Callback::EnterBattleAnimation => self.enter_battle_animation(),
+            Callback::StartBattle => self.start_battle(),
         }
     }
 
@@ -152,10 +153,15 @@ impl Game {
 
     pub fn reset_plants_choose(&mut self) {
         log!("Game scene - Reset PlantsChooser");
+        todo!()
     }
 
-    pub fn start_battle_scene(&mut self) {
-        log!("Game scene - Start Battle");
+    pub fn enter_battle_animation(&mut self) {
+        BattleScene::enter(self)
+    }
+
+    pub fn start_battle(&mut self) {
+        BattleScene::start(self);
     }
 
     // Game State Mutations //
@@ -177,7 +183,21 @@ impl Game {
         self.add_sprites(sprites.as_mut());
     }
 
+    pub fn remove_sprites(&mut self, sprites: Vec<&str>) {
+        self.sprites
+            .retain(|sprite| !sprites.contains(&sprite.name.trim()))
+    }
+
     // Getters //
+    pub fn get_sprite(&mut self, sprite_name: &str) -> &mut Sprite {
+        self.sprites
+            .iter_mut()
+            .find(|sprite| sprite_name == sprite.name)
+            .expect(&format!(
+                "[Game Controller] Cannot find Sprite {}",
+                &sprite_name
+            ))
+    }
 
     pub fn canvas(&self) -> &HtmlCanvasElement {
         &self.painter.canvas

--- a/src/location_builder.rs
+++ b/src/location_builder.rs
@@ -1,9 +1,20 @@
-use crate::model::{Position, Size};
+use crate::model::{LocationType, Position, Size};
 use crate::sprite::Sprite;
 
 pub struct LocationBuilder;
 
 impl LocationBuilder {
+    pub fn locate_text_overlay(
+        sprite: &Sprite,
+        item_dimensions: Size,
+        location_type: &LocationType,
+    ) -> Position {
+        match location_type {
+            LocationType::Center => LocationBuilder::place_at_center(sprite, item_dimensions),
+            LocationType::Top => LocationBuilder::place_at_top(sprite, item_dimensions),
+        }
+    }
+
     pub fn place_at_center(sprite: &Sprite, item_dimensions: Size) -> Position {
         let target_dimensions = sprite.dimensions();
 
@@ -13,5 +24,14 @@ impl LocationBuilder {
             target_dimensions.top + (target_dimensions.height - item_dimensions.height) / 2.0;
 
         Position::new(center_y, center_x)
+    }
+
+    pub fn place_at_top(sprite: &Sprite, item_dimensions: Size) -> Position {
+        let target_dimensions = sprite.dimensions();
+
+        let center_x =
+            target_dimensions.left + (target_dimensions.width - item_dimensions.width) / 2.0;
+
+        Position::new(target_dimensions.top, center_x)
     }
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -68,6 +68,7 @@ pub struct SpriteData {
     pub order: usize,
     pub scale: f64,
     pub exact_outlines: bool,
+    pub draw_offset: Position,
     pub behaviors: Vec<BehaviorData>,
     pub text_overlay: Option<TextOverlayData>,
 }
@@ -76,6 +77,7 @@ impl Default for SpriteData {
     fn default() -> Self {
         Self {
             position: vec![Position::default()],
+            draw_offset: Position::default(),
             order: 1,
             scale: 1.0,
             exact_outlines: false,

--- a/src/model.rs
+++ b/src/model.rs
@@ -126,12 +126,25 @@ pub struct BehaviorData {
     pub max_cycles: Option<usize>,
 }
 
+#[derive(Debug, Clone, Copy, Deserialize)]
+pub enum LocationType {
+    Center,
+    Top,
+}
+
+impl Default for LocationType {
+    fn default() -> Self {
+        LocationType::Center
+    }
+}
+
 #[derive(Debug, Default, Clone, Deserialize)]
 #[serde(default)]
 pub struct TextOverlayData {
     pub text: String,
     pub size: usize,
     pub offset: Option<Position>,
+    pub location_type: LocationType,
 }
 
 #[derive(Debug, Default, PartialEq, Clone, Copy, Deserialize)]

--- a/src/model.rs
+++ b/src/model.rs
@@ -37,6 +37,7 @@ impl fmt::Display for GameMouseEvent {
 pub enum Callback {
     ShowZombieHand,
     StartLevel,
+    BackHome,
 }
 
 impl Default for Callback {

--- a/src/model.rs
+++ b/src/model.rs
@@ -39,6 +39,8 @@ pub enum Callback {
     StartLevel,
     BackHome,
     ShowPlantsChooser,
+    ResetPlantsChoose,
+    StartBattle,
 }
 
 impl Default for Callback {

--- a/src/model.rs
+++ b/src/model.rs
@@ -38,6 +38,7 @@ pub enum Callback {
     ShowZombieHand,
     StartLevel,
     BackHome,
+    ShowPlantsChooser,
 }
 
 impl Default for Callback {
@@ -93,6 +94,7 @@ pub enum BehaviorType {
     Hover,
     Click,
     Animate,
+    Scroll,
 }
 
 impl Default for BehaviorType {
@@ -107,6 +109,7 @@ impl BehaviorType {
             "Click" => BehaviorType::Click,
             "Hover" => BehaviorType::Hover,
             "Animate" => BehaviorType::Animate,
+            "Scroll" => BehaviorType::Scroll,
             _ => BehaviorType::default(),
         }
     }
@@ -117,6 +120,7 @@ impl BehaviorType {
 pub struct BehaviorData {
     pub name: String,
     pub duration: f64,
+    pub distance: f64,
     pub callback: Option<Callback>,
     pub callback_delay: Option<f64>,
     pub max_cycles: Option<usize>,

--- a/src/model.rs
+++ b/src/model.rs
@@ -40,6 +40,7 @@ pub enum Callback {
     BackHome,
     ShowPlantsChooser,
     ResetPlantsChoose,
+    EnterBattleAnimation,
     StartBattle,
 }
 

--- a/src/painter.rs
+++ b/src/painter.rs
@@ -37,6 +37,7 @@ impl Painter {
             self.draw_image(
                 &image_ref,
                 &sprite.position,
+                &sprite.drawing_state.offset,
                 cell,
                 sprite.drawing_state.scale,
             );
@@ -51,9 +52,13 @@ impl Painter {
         &self,
         image: &Rc<HtmlImageElement>,
         pos: &Position,
+        offset: &Position,
         cell: &SpriteCell,
         scale: f64,
     ) {
+        // Setting translate if defined, which will cause a "partial image" view.
+        self.context.translate(-offset.left, -offset.top).unwrap();
+
         self.context
             .draw_image_with_html_image_element_and_sw_and_sh_and_dx_and_dy_and_dw_and_dh(
                 image,
@@ -67,6 +72,9 @@ impl Painter {
                 cell.height * scale,
             )
             .unwrap();
+
+        // Restoring translate
+        self.context.translate(offset.left, offset.top).unwrap();
     }
 
     pub fn draw_text_overlay(&self, text_overlay: &TextOverlay) {

--- a/src/scene/battle.rs
+++ b/src/scene/battle.rs
@@ -1,6 +1,8 @@
 use crate::game::Game;
+use crate::log;
+use crate::model::BehaviorType;
 use crate::resource_loader::ResourceKind;
-use crate::sprite::Sprite;
+use crate::sprite::{BehaviorManager, Sprite};
 
 pub struct BattleScene;
 
@@ -8,10 +10,7 @@ impl BattleScene {
     pub fn start(game: &mut Game) {
         // Show Battle Background
         let mut sprites = Sprite::create_sprites(
-            vec![
-                "BattleBackground",
-                "Button"
-            ],
+            vec!["BattleBackground", "Button"],
             &ResourceKind::Interface,
             &game.resources,
         );
@@ -19,9 +18,19 @@ impl BattleScene {
         // Show Enemies (Zombies)
 
         // Add Scrolling Right behavior
+        BehaviorManager::toggle_behaviors(
+            sprites.iter(),
+            &[BehaviorType::Scroll],
+            true,
+            game.game_time.time,
+        );
 
         // Once Scroll animation is a done, Show the actual PlantsChooser
 
         game.add_sprites(sprites.as_mut());
+    }
+
+    pub fn show_plants_chooser(game: &mut Game) {
+        log!("Showing Plants choooooser");
     }
 }

--- a/src/scene/battle.rs
+++ b/src/scene/battle.rs
@@ -8,16 +8,15 @@ pub struct BattleScene;
 
 impl BattleScene {
     pub fn start(game: &mut Game) {
-        // Show Battle Background
         let mut sprites = Sprite::create_sprites(
-            vec!["BattleBackground", "Button"],
+            vec!["BattleBackground", "BackButton"],
             &ResourceKind::Interface,
             &game.resources,
         );
 
         // Show Enemies (Zombies)
 
-        // Add Scrolling Right behavior
+        // Trigger background scroll
         BehaviorManager::toggle_behaviors(
             sprites.iter(),
             &[BehaviorType::Scroll],
@@ -25,12 +24,16 @@ impl BattleScene {
             game.game_time.time,
         );
 
-        // Once Scroll animation is a done, Show the actual PlantsChooser
-
         game.add_sprites(sprites.as_mut());
     }
 
     pub fn show_plants_chooser(game: &mut Game) {
-        log!("Showing Plants choooooser");
+        let mut sprites = Sprite::create_sprites(
+            vec!["SeedChooserBackground"],
+            &ResourceKind::Interface,
+            &game.resources,
+        );
+
+        game.add_sprites(sprites.as_mut());
     }
 }

--- a/src/scene/battle.rs
+++ b/src/scene/battle.rs
@@ -1,5 +1,6 @@
 use crate::game::Game;
-use crate::model::BehaviorType;
+use crate::log;
+use crate::model::{BehaviorType, Callback};
 use crate::resource_loader::ResourceKind;
 use crate::scene::PlantsChooser;
 use crate::sprite::{BehaviorManager, Sprite};
@@ -14,11 +15,11 @@ impl BattleScene {
             &game.resources,
         );
 
-        // Show Enemies (Zombies)
+        // TODO - Show Enemies (Zombies)
 
         // Trigger background scroll
         BehaviorManager::toggle_behaviors(
-            sprites.iter(),
+            &sprites,
             &[BehaviorType::Scroll],
             true,
             game.game_time.time,
@@ -27,15 +28,20 @@ impl BattleScene {
         game.add_sprites(sprites.as_mut());
     }
 
-    pub fn start(game: &mut Game) {
+    pub fn enter(game: &mut Game) {
+        let now = game.game_time.time;
+
         PlantsChooser::clear(game);
 
-        // TODO - Game find by name.
-        /*        BehaviorManager::toggle_behaviors(
-            sprites.iter(),
-            &[BehaviorType::Scroll],
-            true,
-            game.game_time.time,
-        );*/
+        // Trigger background reverse scroll behavior
+        let background = game.get_sprite("BattleBackground");
+        let scroll = BehaviorManager::get_sprite_behavior(background, BehaviorType::Scroll);
+
+        scroll.reverse(now, Callback::StartBattle);
+    }
+
+    pub fn start(game: &mut Game) {
+        log!("Starting Battle Scene!");
+        todo!()
     }
 }

--- a/src/scene/battle.rs
+++ b/src/scene/battle.rs
@@ -1,0 +1,27 @@
+use crate::game::Game;
+use crate::resource_loader::ResourceKind;
+use crate::sprite::Sprite;
+
+pub struct BattleScene;
+
+impl BattleScene {
+    pub fn start(game: &mut Game) {
+        // Show Battle Background
+        let mut sprites = Sprite::create_sprites(
+            vec![
+                "BattleBackground",
+                "Button"
+            ],
+            &ResourceKind::Interface,
+            &game.resources,
+        );
+
+        // Show Enemies (Zombies)
+
+        // Add Scrolling Right behavior
+
+        // Once Scroll animation is a done, Show the actual PlantsChooser
+
+        game.add_sprites(sprites.as_mut());
+    }
+}

--- a/src/scene/battle.rs
+++ b/src/scene/battle.rs
@@ -1,13 +1,13 @@
 use crate::game::Game;
-use crate::log;
 use crate::model::BehaviorType;
 use crate::resource_loader::ResourceKind;
+use crate::scene::PlantsChooser;
 use crate::sprite::{BehaviorManager, Sprite};
 
 pub struct BattleScene;
 
 impl BattleScene {
-    pub fn start(game: &mut Game) {
+    pub fn prepare(game: &mut Game) {
         let mut sprites = Sprite::create_sprites(
             vec!["BattleBackground", "BackButton"],
             &ResourceKind::Interface,
@@ -27,13 +27,15 @@ impl BattleScene {
         game.add_sprites(sprites.as_mut());
     }
 
-    pub fn show_plants_chooser(game: &mut Game) {
-        let mut sprites = Sprite::create_sprites(
-            vec!["SeedChooserBackground"],
-            &ResourceKind::Interface,
-            &game.resources,
-        );
+    pub fn start(game: &mut Game) {
+        PlantsChooser::clear(game);
 
-        game.add_sprites(sprites.as_mut());
+        // TODO - Game find by name.
+        /*        BehaviorManager::toggle_behaviors(
+            sprites.iter(),
+            &[BehaviorType::Scroll],
+            true,
+            game.game_time.time,
+        );*/
     }
 }

--- a/src/scene/home.rs
+++ b/src/scene/home.rs
@@ -44,7 +44,7 @@ impl HomeScene {
 
         // Activates zombie hand animation Cycle.
         BehaviorManager::toggle_behaviors(
-            zombie_hand.iter(),
+            &zombie_hand,
             &[BehaviorType::Animate],
             true,
             game.game_time.time,

--- a/src/scene/mod.rs
+++ b/src/scene/mod.rs
@@ -1,5 +1,7 @@
 mod battle;
 mod home;
+mod plants_chooser;
 
 pub use battle::BattleScene;
 pub use home::HomeScene;
+pub use plants_chooser::PlantsChooser;

--- a/src/scene/mod.rs
+++ b/src/scene/mod.rs
@@ -1,3 +1,5 @@
+mod battle;
 mod home;
 
+pub use battle::BattleScene;
 pub use home::HomeScene;

--- a/src/scene/plants_chooser.rs
+++ b/src/scene/plants_chooser.rs
@@ -1,0 +1,40 @@
+use crate::game::Game;
+use crate::log;
+use crate::model::{BehaviorType, Position};
+use crate::resource_loader::ResourceKind;
+use crate::sprite::{BehaviorManager, Sprite};
+
+pub struct PlantsChooser;
+
+impl PlantsChooser {
+    fn chooser_sprites() -> Vec<&'static str> {
+        vec!["SeedChooserBackground", "OkButton", "ResetButton"]
+    }
+
+    pub fn show(game: &mut Game) {
+        let mut sprites = Sprite::create_sprites(
+            Self::chooser_sprites(),
+            &ResourceKind::Interface,
+            &game.resources,
+        );
+
+        Self::create_bottom_sun_score(game);
+
+        game.add_sprites(sprites.as_mut());
+    }
+
+    pub fn clear(game: &mut Game) {
+        // TODO Game clear by sprite.
+    }
+
+    fn create_bottom_sun_score(game: &mut Game) {
+        let mut sun_score =
+            Sprite::create_sprite("SunScore", &ResourceKind::Interface, &game.resources).remove(0);
+
+        sun_score.position = Position::new(560.0, 138.0);
+
+        // TODO - Dynamically bound Game sun score into this Sprite TextOverlay.
+
+        game.add_sprite(sun_score);
+    }
+}

--- a/src/scene/plants_chooser.rs
+++ b/src/scene/plants_chooser.rs
@@ -24,7 +24,11 @@ impl PlantsChooser {
     }
 
     pub fn clear(game: &mut Game) {
-        // TODO Game clear by sprite.
+        let mut scene_sprites = vec!["SunScore"];
+
+        scene_sprites.append(Self::chooser_sprites().as_mut());
+
+        game.remove_sprites(scene_sprites);
     }
 
     fn create_bottom_sun_score(game: &mut Game) {

--- a/src/sprite/base.rs
+++ b/src/sprite/base.rs
@@ -29,6 +29,7 @@ impl Sprite {
         name: &str,
         order: usize,
         position: Position,
+        draw_offset: Position,
         cells: Vec<SpriteCell>,
         image: Option<Weak<HtmlImageElement>>,
         scale: f64,
@@ -49,7 +50,7 @@ impl Sprite {
             order,
             position,
             image,
-            drawing_state: DrawingState::new(cells, scale),
+            drawing_state: DrawingState::new(cells, scale, draw_offset),
             outlines: vec![],
             behaviors: sprite_behaviors,
             text_overlay: None,
@@ -97,6 +98,7 @@ impl Sprite {
 
         let SpriteData {
             position,
+            draw_offset,
             order,
             scale,
             behaviors,
@@ -114,6 +116,7 @@ impl Sprite {
                     sprite_name,
                     order,
                     *position,
+                    draw_offset,
                     resource.cell,
                     resource.image,
                     scale,

--- a/src/sprite/base.rs
+++ b/src/sprite/base.rs
@@ -143,7 +143,8 @@ impl Sprite {
             }
 
             if let Some(position) = mutation.position {
-                log!("TODO - Sprite position Changed")
+                log!("TODO - Sprite position Changed");
+                todo!()
             }
         });
     }

--- a/src/sprite/base.rs
+++ b/src/sprite/base.rs
@@ -138,6 +138,10 @@ impl Sprite {
                 self.drawing_state.cycle_cells();
             }
 
+            if let Some(offset) = mutation.offset {
+                self.drawing_state.offset = offset;
+            }
+
             if let Some(position) = mutation.position {
                 log!("TODO - Sprite position Changed")
             }

--- a/src/sprite/behavior/base.rs
+++ b/src/sprite/behavior/base.rs
@@ -1,6 +1,6 @@
 use web_sys::CanvasRenderingContext2d;
 
-use crate::model::{BehaviorType, GameInteraction, Position};
+use crate::model::{BehaviorType, Callback, GameInteraction, Position};
 use crate::sprite::{Sprite, SpriteMutation};
 
 pub trait BehaviorState {
@@ -26,6 +26,8 @@ pub trait Behavior: BehaviorState {
     fn get_interaction(&self) -> Option<GameInteraction> {
         return None;
     }
+
+    fn reverse(&mut self, _now: f64, _callback: Callback) {}
 
     fn execute(
         &mut self,

--- a/src/sprite/behavior/mod.rs
+++ b/src/sprite/behavior/mod.rs
@@ -2,6 +2,7 @@ mod animate;
 mod base;
 mod click;
 mod hover;
+mod scroll;
 
 use std::slice::Iter;
 
@@ -9,6 +10,7 @@ pub use animate::Animate;
 pub use base::Behavior;
 pub use click::Click;
 pub use hover::Hover;
+pub use scroll::Scroll;
 use web_sys::CanvasRenderingContext2d;
 
 use crate::model::{BehaviorData, BehaviorType, GameInteraction, Position};
@@ -30,6 +32,11 @@ impl BehaviorManager {
                 data.max_cycles,
             )),
             BehaviorType::Hover => Box::new(Hover::new()),
+            BehaviorType::Scroll => Box::new(Scroll::new(
+                data.distance,
+                data.duration,
+                data.callback.unwrap(),
+            )),
         }
     }
 

--- a/src/sprite/behavior/mod.rs
+++ b/src/sprite/behavior/mod.rs
@@ -4,8 +4,6 @@ mod click;
 mod hover;
 mod scroll;
 
-use std::slice::Iter;
-
 pub use animate::Animate;
 pub use base::Behavior;
 pub use click::Click;
@@ -58,18 +56,32 @@ impl BehaviorManager {
     }
 
     pub fn toggle_behaviors(
-        sprites: Iter<Sprite>,
+        sprites: &Vec<Sprite>,
         behavior_types: &[BehaviorType],
         should_run: bool,
         now: f64,
     ) {
-        sprites.for_each(|sprite| {
+        sprites.iter().for_each(|sprite| {
             sprite
                 .mutable_behaviors()
                 .iter_mut()
                 .filter(|behavior| behavior_types.contains(&behavior.name()))
                 .for_each(|behavior| behavior.toggle(should_run, now));
         });
+    }
+
+    pub fn get_sprite_behavior(
+        sprite: &mut Sprite,
+        behavior: BehaviorType,
+    ) -> &mut Box<dyn Behavior> {
+        let behavior = sprite
+            .behaviors
+            .get_mut()
+            .iter_mut()
+            .find(|sprite_behavior| behavior == sprite_behavior.name())
+            .expect(&format!("[BehaviorManager] Cannot find Sprite behavior: {:?}", behavior));
+
+        behavior
     }
 
     pub fn collect_interactions(sprite: &Sprite) -> Vec<GameInteraction> {

--- a/src/sprite/behavior/scroll.rs
+++ b/src/sprite/behavior/scroll.rs
@@ -1,0 +1,68 @@
+use derives::{derive_behavior_fields, BaseBehavior};
+use web_sys::CanvasRenderingContext2d;
+
+use super::base::Behavior;
+use crate::log;
+use crate::model::{BehaviorType, Callback, Position};
+use crate::sprite::{Sprite, SpriteMutation};
+
+const SCROLL_ADDITION: f64 = 8.5;
+
+#[derive_behavior_fields("")]
+#[derive(BaseBehavior, Default)]
+pub struct Scroll {
+    name: BehaviorType,
+    callback: Callback,
+    distance: f64,
+    duration: f64,
+    last_tick: f64,
+    scrolled_distance: f64,
+}
+
+impl Scroll {
+    pub fn new(distance: f64, duration: f64, callback: Callback) -> Scroll {
+        Scroll {
+            callback,
+            duration,
+            distance,
+            name: BehaviorType::Click,
+            ..Default::default()
+        }
+    }
+}
+
+impl Behavior for Scroll {
+    fn name(&self) -> BehaviorType {
+        BehaviorType::Scroll
+    }
+
+    fn execute(
+        &mut self,
+        sprite: &Sprite,
+        now: f64,
+        _last_frame: f64,
+        _mouse: &Position,
+        _context: &CanvasRenderingContext2d,
+    ) -> Option<SpriteMutation> {
+        let finished = self.scrolled_distance >= self.distance;
+        let should_scroll = now - self.last_tick >= self.duration;
+
+        if finished {
+            log!("Finished scrolling Triggering callback!");
+            return None;
+        }
+
+        if should_scroll {
+            self.last_tick = now;
+            self.scrolled_distance += SCROLL_ADDITION;
+            let current_offset = &sprite.drawing_state.offset;
+
+            return Some(SpriteMutation::new().offset(Position::new(
+                current_offset.top,
+                current_offset.left + SCROLL_ADDITION,
+            )));
+        }
+
+        None
+    }
+}

--- a/src/sprite/behavior/scroll.rs
+++ b/src/sprite/behavior/scroll.rs
@@ -3,7 +3,7 @@ use web_sys::CanvasRenderingContext2d;
 
 use super::base::Behavior;
 use crate::log;
-use crate::model::{BehaviorType, Callback, Position};
+use crate::model::{BehaviorType, Callback, GameInteraction, Position};
 use crate::sprite::{Sprite, SpriteMutation};
 
 const SCROLL_ADDITION: f64 = 8.5;
@@ -36,6 +36,14 @@ impl Behavior for Scroll {
         BehaviorType::Scroll
     }
 
+    fn get_interaction(&self) -> Option<GameInteraction> {
+        if self.interaction_active {
+            return Some(GameInteraction::SpriteClick(self.callback));
+        }
+
+        None
+    }
+
     fn execute(
         &mut self,
         sprite: &Sprite,
@@ -48,10 +56,14 @@ impl Behavior for Scroll {
         let should_scroll = now - self.last_tick >= self.duration;
 
         if finished {
-            log!("Finished scrolling Triggering callback!");
+            self.stop(now);
+            self.interaction_active = true;
+
             return None;
         }
 
+        // TODO - Needs to consider also directions e.g Starts with right, a ends with a left once re-toggled
+        // State will be preserved so we can tell if we directed.
         if should_scroll {
             self.last_tick = now;
             self.scrolled_distance += SCROLL_ADDITION;

--- a/src/sprite/drawing_state.rs
+++ b/src/sprite/drawing_state.rs
@@ -1,4 +1,4 @@
-use crate::model::SpriteCell;
+use crate::model::{Position, SpriteCell};
 use crate::sprite::Sprite;
 
 #[derive(Debug, Default)]
@@ -6,13 +6,15 @@ pub struct DrawingState {
     pub cells: Vec<SpriteCell>,
     pub active_cell: usize,
     pub scale: f64,
+    pub offset: Position,
 }
 
 impl DrawingState {
-    pub fn new(cells: Vec<SpriteCell>, scale: f64) -> Self {
+    pub fn new(cells: Vec<SpriteCell>, scale: f64, offset: Position) -> Self {
         Self {
             scale,
             cells,
+            offset,
             ..DrawingState::default()
         }
     }

--- a/src/sprite/mod.rs
+++ b/src/sprite/mod.rs
@@ -6,7 +6,7 @@ mod outline;
 mod text_overlay;
 
 pub use base::Sprite;
-pub use behavior::{BehaviorManager, Hover};
+pub use behavior::{BehaviorManager, Click, Hover, Scroll};
 pub use drawing_state::DrawingState;
 pub use model::SpriteMutation;
 pub use outline::Outline;

--- a/src/sprite/model.rs
+++ b/src/sprite/model.rs
@@ -2,6 +2,7 @@ use crate::model::Position;
 
 pub struct SpriteMutation {
     pub position: Option<Position>,
+    pub offset: Option<Position>,
     pub hovered: Option<bool>,
     pub cycle_cells: Option<bool>,
 }
@@ -10,6 +11,7 @@ impl SpriteMutation {
     pub fn new() -> Self {
         Self {
             position: None,
+            offset: None,
             hovered: None,
             cycle_cells: None,
         }
@@ -17,6 +19,12 @@ impl SpriteMutation {
 
     pub fn position(mut self, position: Position) -> Self {
         self.position = Some(position);
+
+        self
+    }
+
+    pub fn offset(mut self, offset: Position) -> Self {
+        self.offset = Some(offset);
 
         self
     }

--- a/src/sprite/outline/mod.rs
+++ b/src/sprite/outline/mod.rs
@@ -56,8 +56,8 @@ impl Outline {
         // Get measurements painter for off screen drawings
         let painter = Painter::get_measurements_painter(size);
 
-        let image_draw_start = Position::new(0.0, 0.0);
-        painter.draw_image(&image_ref, &image_draw_start, cell, scale);
+        let starting_point = Position::new(0.0, 0.0);
+        painter.draw_image(&image_ref, &starting_point, &starting_point, cell, scale);
 
         let image_data = painter
             .context

--- a/src/sprite/text_overlay.rs
+++ b/src/sprite/text_overlay.rs
@@ -1,4 +1,3 @@
-
 use crate::location_builder::LocationBuilder;
 use crate::model::{Position, TextOverlayData};
 use crate::painter::Painter;

--- a/src/sprite/text_overlay.rs
+++ b/src/sprite/text_overlay.rs
@@ -1,5 +1,5 @@
 use crate::location_builder::LocationBuilder;
-use crate::model::{Position, TextOverlayData};
+use crate::model::{LocationType, Position, TextOverlayData};
 use crate::painter::Painter;
 use crate::sprite::Sprite;
 
@@ -9,6 +9,7 @@ pub struct TextOverlay {
     pub text: String,
     pub size: usize,
     pub position: Option<Position>,
+    pub location_type: LocationType,
 }
 
 impl TextOverlay {
@@ -18,6 +19,7 @@ impl TextOverlay {
             size: data.size,
             offset: data.offset,
             position: None,
+            location_type: data.location_type,
         };
 
         overlay.calculate_text_position(source_sprite);
@@ -30,6 +32,10 @@ impl TextOverlay {
         let text_size = Painter::measure_text(&self.text, self.size);
 
         // Placing text at the center of the given source sprite.
-        self.position = Some(LocationBuilder::place_at_center(source_sprite, text_size));
+        self.position = Some(LocationBuilder::locate_text_overlay(
+            source_sprite,
+            text_size,
+            &self.location_type,
+        ));
     }
 }


### PR DESCRIPTION
**Main changes**

Implementing the Start scene of the `BattleScene` which starts which a plain Background with a scrolling effect, which ends with a `PlantsChooser` scene.

`PlantsChooser` scene enables the user to select Plants he wish to participate in over the current level and have `Reset` / `Ok` buttons.
Once the user approves, the `PlantsChooser` items vanishes and the `EnterBattleAnimation` kicks in with a reverse 

- Add `Scroll` behavior to trigger Background scrolling animation ( **Only one direction is supported for now tho it miss the other direction** ) 

**Side effects** 
- `Sprite` has the ability to define a `draw_offest` which than painter will know to respect and translate the image accordingly.
- `LocationBuilder` has now has the ability to accept a `LocationType` for different locations placemenets.
- Add a `find_sprite` Game method for finding a sprite a given sprite by name / kind.
- Add `find_sprite_behavior` for retrieving a mutable instance of a given behavior of a Sprite.

**Missing:**
`BattleScene/prepare` - once enter, it should display the `Zombies` enemies.
`PlantsChooser` scene - Cards selection controller.
`EnterBattleAnimation` - Missing "Get Ready to Fight!" text animation.
