### PR TITLE
Plants chooser cards selection scene

### DIFF
--- a/assets/json/card-data.json
+++ b/assets/json/card-data.json
@@ -3,7 +3,7 @@
     "constructor": "Sprite",
     "position": [{ "left": 0, "top": 0 }],
     "behaviors": [{ "name": "Click",
-      "callback": "ToggleCardSelection"
+      "callback": "ChooserSeedSelect"
     }],
     "scale": 0.725,
     "order": 3
@@ -12,7 +12,7 @@
     "constructor": "Sprite",
     "position": [{ "left": 0, "top": 0 }],
     "behaviors": [{ "name": "Click",
-      "callback": "ToggleCardSelection"
+      "callback": "ChooserSeedSelect"
     }],
     "scale": 0.725,
     "order": 3
@@ -20,35 +20,35 @@
   "SnowPea": {
     "constructor": "Sprite",
     "position": [{ "left": 0, "top": 0 }],
-    "behaviors": [{ "name": "Click", "callback": "ToggleCardSelection" }],
+    "behaviors": [{ "name": "Click", "callback": "ChooserSeedSelect" }],
     "scale": 0.725,
     "order": 3
   },
   "WallNut": {
     "constructor": "Sprite",
     "position": [{ "left": 0, "top": 0 }],
-    "behaviors": [{ "name": "Click", "callback": "ToggleCardSelection" }],
+    "behaviors": [{ "name": "Click", "callback": "ChooserSeedSelect" }],
     "scale": 0.725,
     "order": 3
   },
   "Torchwood": {
     "constructor": "Sprite",
     "position": [{ "left": 0, "top": 0 }],
-    "behaviors": [{ "name": "Click", "callback": "ToggleCardSelection" }],
+    "behaviors": [{ "name": "Click", "callback": "ChooserSeedSelect" }],
     "scale": 0.725,
     "order": 3
   },
   "PumpkinHead": {
     "constructor": "Sprite",
     "position": [{ "left": 0, "top": 0 }],
-    "behaviors": [{ "name": "Click", "callback": "ToggleCardSelection" }],
+    "behaviors": [{ "name": "Click", "callback": "ChooserSeedSelect" }],
     "scale": 0.725,
     "order": 3
   },
   "TallNut": {
     "constructor": "Sprite",
     "position": [{ "left": 0, "top": 0 }],
-    "behaviors": [{ "name": "Click", "callback": "ToggleCardSelection" }],
+    "behaviors": [{ "name": "Click", "callback": "ChooserSeedSelect" }],
     "scale": 0.725,
     "order": 3
   }

--- a/assets/json/card-data.json
+++ b/assets/json/card-data.json
@@ -2,49 +2,53 @@
   "SunFlower": {
     "constructor": "Sprite",
     "position": [{ "left": 0, "top": 0 }],
-    "behaviors": [{ "name": "Click" }],
+    "behaviors": [{ "name": "Click",
+      "callback": "BackHome"
+    }],
     "scale": 0.725,
     "order": 3
   },
   "Peashooter": {
     "constructor": "Sprite",
     "position": [{ "left": 0, "top": 0 }],
-    "behaviors": [{ "name": "Click" }],
+    "behaviors": [{ "name": "Click",
+      "callback": "BackHome"
+    }],
     "scale": 0.725,
     "order": 3
   },
   "SnowPea": {
     "constructor": "Sprite",
     "position": [{ "left": 0, "top": 0 }],
-    "behaviors": [{ "name": "Click" }],
+    "behaviors": [{ "name": "Click", "callback": "BackHome" }],
     "scale": 0.725,
     "order": 3
   },
   "WallNut": {
     "constructor": "Sprite",
     "position": [{ "left": 0, "top": 0 }],
-    "behaviors": [{ "name": "Click" }],
+    "behaviors": [{ "name": "Click", "callback": "BackHome" }],
     "scale": 0.725,
     "order": 3
   },
   "Torchwood": {
     "constructor": "Sprite",
     "position": [{ "left": 0, "top": 0 }],
-    "behaviors": [{ "name": "Click" }],
+    "behaviors": [{ "name": "Click", "callback": "BackHome" }],
     "scale": 0.725,
     "order": 3
   },
   "PumpkinHead": {
     "constructor": "Sprite",
     "position": [{ "left": 0, "top": 0 }],
-    "behaviors": [{ "name": "Click" }],
+    "behaviors": [{ "name": "Click", "callback": "BackHome" }],
     "scale": 0.725,
     "order": 3
   },
   "TallNut": {
     "constructor": "Sprite",
     "position": [{ "left": 0, "top": 0 }],
-    "behaviors": [{ "name": "Click" }],
+    "behaviors": [{ "name": "Click", "callback": "BackHome" }],
     "scale": 0.725,
     "order": 3
   }

--- a/assets/json/card-data.json
+++ b/assets/json/card-data.json
@@ -3,7 +3,7 @@
     "constructor": "Sprite",
     "position": [{ "left": 0, "top": 0 }],
     "behaviors": [{ "name": "Click",
-      "callback": "BackHome"
+      "callback": "ToggleCardSelection"
     }],
     "scale": 0.725,
     "order": 3
@@ -12,7 +12,7 @@
     "constructor": "Sprite",
     "position": [{ "left": 0, "top": 0 }],
     "behaviors": [{ "name": "Click",
-      "callback": "BackHome"
+      "callback": "ToggleCardSelection"
     }],
     "scale": 0.725,
     "order": 3
@@ -20,35 +20,35 @@
   "SnowPea": {
     "constructor": "Sprite",
     "position": [{ "left": 0, "top": 0 }],
-    "behaviors": [{ "name": "Click", "callback": "BackHome" }],
+    "behaviors": [{ "name": "Click", "callback": "ToggleCardSelection" }],
     "scale": 0.725,
     "order": 3
   },
   "WallNut": {
     "constructor": "Sprite",
     "position": [{ "left": 0, "top": 0 }],
-    "behaviors": [{ "name": "Click", "callback": "BackHome" }],
+    "behaviors": [{ "name": "Click", "callback": "ToggleCardSelection" }],
     "scale": 0.725,
     "order": 3
   },
   "Torchwood": {
     "constructor": "Sprite",
     "position": [{ "left": 0, "top": 0 }],
-    "behaviors": [{ "name": "Click", "callback": "BackHome" }],
+    "behaviors": [{ "name": "Click", "callback": "ToggleCardSelection" }],
     "scale": 0.725,
     "order": 3
   },
   "PumpkinHead": {
     "constructor": "Sprite",
     "position": [{ "left": 0, "top": 0 }],
-    "behaviors": [{ "name": "Click", "callback": "BackHome" }],
+    "behaviors": [{ "name": "Click", "callback": "ToggleCardSelection" }],
     "scale": 0.725,
     "order": 3
   },
   "TallNut": {
     "constructor": "Sprite",
     "position": [{ "left": 0, "top": 0 }],
-    "behaviors": [{ "name": "Click", "callback": "BackHome" }],
+    "behaviors": [{ "name": "Click", "callback": "ToggleCardSelection" }],
     "scale": 0.725,
     "order": 3
   }

--- a/assets/json/interface-data.json
+++ b/assets/json/interface-data.json
@@ -38,7 +38,7 @@
   "SelectorZombieHand": {
     "constructor": "Sprite",
     "position": [{ "left": 262, "top": 264 }],
-    "behaviors": [{ "name": "Animate", "duration": 120, "callback": "StartLevel" }]
+    "behaviors": [{ "name": "Animate", "duration": 120, "callback": "SelectLevel" }]
   },
   "SelectorWoodSign1": {
     "constructor": "Sprite",

--- a/assets/json/level-data.json
+++ b/assets/json/level-data.json
@@ -2,15 +2,7 @@
   "1-1": {
     "name": "1-1",
     "flag_num": 3,
-    "scenes": [
-      "BattleBackground",
-      "ShovelBack",
-      "Shovel",
-      "Button",
-      "LawnCleaner",
-      "PrepareGrowPlants"
-    ],
-    "plants_options": [
+    "plant_cards": [
       "SunFlower",
       "Peashooter",
       "SnowPea",

--- a/derives/src/behavior.rs
+++ b/derives/src/behavior.rs
@@ -26,6 +26,10 @@ pub fn impl_base_bevhior_derive(parsed_input: DeriveInput) -> TokenStream {
                     fn clean_interaction(&mut self) {
                         self.interaction_active = false
                     }
+
+                    fn set_sprite_id(&mut self, sprite_id: String) {
+                        self.sprite_id = sprite_id;
+                    }
                 }
             };
 

--- a/derives/src/behavior_field.rs
+++ b/derives/src/behavior_field.rs
@@ -36,6 +36,7 @@ impl BehaviorMacroInput {
             BehaviorDerivedType::DEFAULT => vec![
                 quote!(running: bool,).into(),
                 quote!(interaction_active: bool,).into(),
+                quote!(sprite_id: String,).into(),
             ]
         }
     }

--- a/src/game.rs
+++ b/src/game.rs
@@ -164,12 +164,6 @@ impl Game {
     }
 
     pub fn reset_plants_choose(&mut self) {
-        self.get_sprites_by_type(&SpriteType::Seed)
-            .iter_mut()
-            .for_each(|seed| {
-                seed.drawing_state.hover(false);
-            });
-
         PlantsChooser::reset_selection(self);
 
         self.state.selected_seeds = vec![];
@@ -191,9 +185,6 @@ impl Game {
             &selected_seed.0 == clicked_sprite_id || &selected_seed.1 == clicked_sprite_id
         });
 
-        let clicked_sprite = self.get_sprite_by_id(clicked_sprite_id);
-        let name = clicked_sprite.name.clone();
-
         if let Some(selected) = selected {
             let is_seed_click = clicked_sprite_id == &selected.0;
 
@@ -207,17 +198,9 @@ impl Game {
                 .selected_seeds
                 .retain(|(_seed_id, card_id)| card_id != clicked_sprite_id);
 
-            let seed_sprite = self.get_sprite_by_id(&selected.0);
-            seed_sprite.drawing_state.hover(false);
-
-            self.remove_sprites_by_id(vec![&selected.1]);
-
-            BattleScene::update_selected_cards_layout(self);
+            BattleScene::deselect_seed(self, &selected);
         } else {
-            // Selecting Seed and adding Card.
-            clicked_sprite.drawing_state.hover(true);
-
-            let card_id = BattleScene::add_plant_card(self, &name);
+            let card_id = BattleScene::select_seed(self, clicked_sprite_id);
 
             self.state
                 .selected_seeds

--- a/src/game.rs
+++ b/src/game.rs
@@ -1,15 +1,13 @@
-use std::borrow::Borrow;
-
 use web_sys::{HtmlCanvasElement, MouseEvent};
 
 use crate::fps::Fps;
 use crate::log;
 use crate::model::{
-    BehaviorType, Callback, GameInteraction, GameMouseEvent, GameState, LevelData, Position,
+    BehaviorType, Callback, GameInteraction, GameMouseEvent, GameState, Position,
     SpriteType,
 };
 use crate::painter::Painter;
-use crate::resource_loader::{ResourceKind, Resources};
+use crate::resource_loader::{Resources};
 use crate::scene::{BattleScene, HomeScene, PlantsChooser};
 use crate::sprite::{BehaviorManager, Sprite};
 use crate::timers::GameTime;

--- a/src/game.rs
+++ b/src/game.rs
@@ -153,7 +153,6 @@ impl Game {
 
     pub fn reset_plants_choose(&mut self) {
         log!("Game scene - Reset PlantsChooser");
-        todo!()
     }
 
     pub fn enter_battle_animation(&mut self) {

--- a/src/game.rs
+++ b/src/game.rs
@@ -128,6 +128,7 @@ impl Game {
             Callback::ResetPlantsChoose => self.reset_plants_choose(),
             Callback::EnterBattleAnimation => self.enter_battle_animation(),
             Callback::StartBattle => self.start_battle(),
+            Callback::ToggleCardSelection => self.toggle_card_selection(),
         }
     }
 
@@ -170,6 +171,10 @@ impl Game {
         BattleScene::start(self);
     }
 
+    pub fn toggle_card_selection(&mut self) {
+        log!("Game scene - Card selected");
+    }
+
     // Game State Mutations //
 
     pub fn reset_state(&mut self) {
@@ -204,14 +209,6 @@ impl Game {
                 "[Game Controller] Cannot find Sprite {}",
                 &sprite_name
             ))
-    }
-
-    pub fn current_level_cards(&self) -> Vec<&str> {
-        self.selected_level
-            .plant_cards
-            .iter()
-            .map(|card| card.trim())
-            .collect::<Vec<&str>>()
     }
 
     pub fn canvas(&self) -> &HtmlCanvasElement {

--- a/src/location_builder.rs
+++ b/src/location_builder.rs
@@ -10,12 +10,32 @@ impl LocationBuilder {
         location_type: &LocationType,
     ) -> Position {
         match location_type {
-            LocationType::Center => LocationBuilder::place_at_center(sprite, item_dimensions),
-            LocationType::Top => LocationBuilder::place_at_top(sprite, item_dimensions),
+            LocationType::Center => Self::place_at_center(sprite, item_dimensions),
+            LocationType::Top => Self::place_at_top(sprite, item_dimensions),
         }
     }
 
-    pub fn place_at_center(sprite: &Sprite, item_dimensions: Size) -> Position {
+    pub fn create_row_layout(
+        initial_position: &Position,
+        amount: usize,
+        max: usize,
+        item_size: Size,
+    ) -> Vec<Position> {
+        let mut row_layout = vec![];
+
+        for i in 0..amount {
+            let (row, col) = (i / max, i % max);
+
+            row_layout.push(Position::new(
+                initial_position.top + item_size.height * row as f64,
+                initial_position.left + item_size.width * col as f64,
+            ));
+        }
+
+        row_layout
+    }
+
+    fn place_at_center(sprite: &Sprite, item_dimensions: Size) -> Position {
         let target_dimensions = sprite.dimensions();
 
         let center_x =
@@ -26,7 +46,7 @@ impl LocationBuilder {
         Position::new(center_y, center_x)
     }
 
-    pub fn place_at_top(sprite: &Sprite, item_dimensions: Size) -> Position {
+    fn place_at_top(sprite: &Sprite, item_dimensions: Size) -> Position {
         let target_dimensions = sprite.dimensions();
 
         let center_x =

--- a/src/model.rs
+++ b/src/model.rs
@@ -36,7 +36,7 @@ impl fmt::Display for GameMouseEvent {
 #[derive(Debug, Clone, Copy, Deserialize)]
 pub enum Callback {
     ShowZombieHand,
-    StartLevel,
+    SelectLevel,
     BackHome,
     ShowPlantsChooser,
     ResetPlantsChoose,
@@ -199,11 +199,18 @@ impl From<TextMetrics> for Size {
     }
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Default, Deserialize)]
 pub struct LevelData {
     pub name: String,
-    pub scenes: Vec<String>,
     pub flag_num: usize,
-    pub plants_options: Vec<String>,
+    pub plant_cards: Vec<String>,
     pub zombies: Vec<String>,
+}
+
+impl LevelData {
+    pub fn new() -> Self {
+        LevelData {
+            ..LevelData::default()
+        }
+    }
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -5,7 +5,7 @@ use web_sys::{MouseEvent, TextMetrics};
 
 use crate::resource_loader::ResourceKind;
 
-type SelectedSeed = (String, String);
+pub type SelectedSeed = (String, String);
 
 #[derive(Debug, Default)]
 pub struct GameState {

--- a/src/model.rs
+++ b/src/model.rs
@@ -3,11 +3,15 @@ use std::fmt;
 use serde_derive::Deserialize;
 use web_sys::{MouseEvent, TextMetrics};
 
+use crate::resource_loader::ResourceKind;
+
+type SelectedSeed = (String, String);
+
 #[derive(Debug, Default)]
 pub struct GameState {
     pub sun: usize,
     pub current_level: Option<LevelData>,
-    pub selected_seeds: Vec<String>,
+    pub selected_seeds: Vec<SelectedSeed>,
 }
 
 impl GameState {
@@ -52,6 +56,7 @@ pub enum Callback {
     EnterBattleAnimation,
     StartBattle,
     ChooserSeedSelect,
+    PlantCardClick,
 }
 
 impl Default for Callback {
@@ -66,6 +71,28 @@ type SpriteId = String;
 pub enum GameInteraction {
     SpriteClick(Callback, SpriteId),
     AnimationCallback(Callback),
+}
+
+#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+pub enum SpriteType {
+    Zombie,
+    Plant,
+    Interface,
+    Card,
+    Seed,
+    Meta,
+}
+
+impl SpriteType {
+    pub fn from_kind(kind: &ResourceKind) -> Self {
+        match kind {
+            ResourceKind::Card => SpriteType::Card,
+            ResourceKind::Interface => SpriteType::Interface,
+            ResourceKind::Plant => SpriteType::Plant,
+            ResourceKind::Zombie => SpriteType::Zombie,
+            ResourceKind::Level => SpriteType::Meta,
+        }
+    }
 }
 
 /// Sprite cell represents a Sprite given possible states position pointing to a respective interface asset.

--- a/src/model.rs
+++ b/src/model.rs
@@ -42,6 +42,7 @@ pub enum Callback {
     ResetPlantsChoose,
     EnterBattleAnimation,
     StartBattle,
+    ToggleCardSelection,
 }
 
 impl Default for Callback {

--- a/src/model.rs
+++ b/src/model.rs
@@ -7,6 +7,7 @@ use web_sys::{MouseEvent, TextMetrics};
 pub struct GameState {
     pub sun: usize,
     pub current_level: Option<LevelData>,
+    pub selected_seeds: Vec<String>,
 }
 
 impl GameState {
@@ -14,6 +15,14 @@ impl GameState {
         GameState {
             sun: 600,
             current_level: None,
+            selected_seeds: vec![],
+        }
+    }
+
+    pub fn get_level(&self) -> LevelData {
+        match &self.current_level {
+            Some(level) => level.clone(),
+            None => LevelData::new(),
         }
     }
 }
@@ -42,7 +51,7 @@ pub enum Callback {
     ResetPlantsChoose,
     EnterBattleAnimation,
     StartBattle,
-    ToggleCardSelection,
+    ChooserSeedSelect,
 }
 
 impl Default for Callback {
@@ -51,9 +60,11 @@ impl Default for Callback {
     }
 }
 
+type SpriteId = String;
+
 #[derive(Debug)]
 pub enum GameInteraction {
-    SpriteClick(Callback),
+    SpriteClick(Callback, SpriteId),
     AnimationCallback(Callback),
 }
 

--- a/src/resource_loader/mod.rs
+++ b/src/resource_loader/mod.rs
@@ -60,6 +60,14 @@ impl Resources {
             },
         }
     }
+
+    pub fn get_level_data(&self, level_id: &str) -> LevelData {
+        let resource_key = format!("{}/{}", ResourceKind::Level.value(), level_id);
+
+        let level_data = self.level_data.get(&resource_key).unwrap();
+
+        level_data.clone()
+    }
 }
 
 impl ResourceLoader {

--- a/src/resource_loader/model.rs
+++ b/src/resource_loader/model.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, Hash, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Hash, Eq, PartialEq)]
 pub enum ResourceKind {
     Card,
     Interface,

--- a/src/scene/battle.rs
+++ b/src/scene/battle.rs
@@ -15,6 +15,12 @@ impl BattleScene {
             &game.resources,
         );
 
+        let mut cards = Sprite::create_sprites(
+            vec!["SunFlower", "Peashooter"],
+            &ResourceKind::Card,
+            &game.resources,
+        );
+
         // TODO - Show Enemies (Zombies)
 
         // Trigger background scroll
@@ -26,6 +32,7 @@ impl BattleScene {
         );
 
         game.add_sprites(sprites.as_mut());
+        game.add_sprites(cards.as_mut());
     }
 
     pub fn enter(game: &mut Game) {
@@ -34,7 +41,7 @@ impl BattleScene {
         PlantsChooser::clear(game);
 
         // Trigger background reverse scroll behavior
-        let background = game.get_sprite("BattleBackground");
+        let background = game.get_sprite("BattleBackground", &ResourceKind::Interface);
         let scroll = BehaviorManager::get_sprite_behavior(background, BehaviorType::Scroll);
 
         scroll.reverse(now, Callback::StartBattle);

--- a/src/scene/battle.rs
+++ b/src/scene/battle.rs
@@ -1,6 +1,6 @@
 use crate::game::Game;
 use crate::log;
-use crate::model::{BehaviorType, Callback};
+use crate::model::{BehaviorType, Callback, Position, SpriteType};
 use crate::resource_loader::ResourceKind;
 use crate::scene::PlantsChooser;
 use crate::sprite::{BehaviorManager, Sprite};
@@ -34,18 +34,43 @@ impl BattleScene {
         PlantsChooser::clear(game);
 
         // Trigger background reverse scroll behavior
-        let background =
-            game.get_sprite_by_name_and_kind("BattleBackground", &ResourceKind::Interface);
+        let background = game.get_sprite_by_name_and_type("BattleBackground", &SpriteType::Interface);
         let scroll = BehaviorManager::get_sprite_behavior(background, BehaviorType::Scroll);
 
         scroll.reverse(now, Callback::StartBattle);
     }
 
-    pub fn draw_selected_seeds(game: &mut Game) {
-        log!("Selected cards: {:?}", game.state.selected_seeds);
+    pub fn add_plant_card(game: &mut Game, seed_name: &str) -> String {
+        let current_cards = game.state.selected_seeds.len();
+
+        let mut plant =
+            Sprite::create_sprite(seed_name, &ResourceKind::Card, &game.resources).remove(0);
+
+        let plant_id = plant.id.clone();
+
+        plant.update_position(Position::new(60.0 * current_cards as f64, 0.0));
+        plant.drawing_state.scale = 1.0;
+
+        game.add_sprite(plant);
+
+        plant_id
+    }
+
+    pub fn update_selected_cards_layout(game: &mut Game) {
+        let mut count = 0;
+        let selected_seeds = &game.state.selected_seeds.to_vec();
+
+        selected_seeds.iter().for_each(|(_seed_id, card_id)| {
+            let card_sprite = game.get_sprite_by_id(card_id);
+
+            card_sprite.update_position(Position::new(60.0 * count as f64, 0.0));
+
+            count += 1;
+        })
     }
 
     pub fn start(game: &mut Game) {
+        // TODO - Swap cards Callback to Plant action.
         log!("Starting Battle Scene!");
     }
 }

--- a/src/scene/battle.rs
+++ b/src/scene/battle.rs
@@ -34,10 +34,15 @@ impl BattleScene {
         PlantsChooser::clear(game);
 
         // Trigger background reverse scroll behavior
-        let background = game.get_sprite("BattleBackground", &ResourceKind::Interface);
+        let background =
+            game.get_sprite_by_name_and_kind("BattleBackground", &ResourceKind::Interface);
         let scroll = BehaviorManager::get_sprite_behavior(background, BehaviorType::Scroll);
 
         scroll.reverse(now, Callback::StartBattle);
+    }
+
+    pub fn draw_selected_seeds(game: &mut Game) {
+        log!("Selected cards: {:?}", game.state.selected_seeds);
     }
 
     pub fn start(game: &mut Game) {

--- a/src/scene/battle.rs
+++ b/src/scene/battle.rs
@@ -1,6 +1,6 @@
 use crate::game::Game;
 use crate::log;
-use crate::model::{BehaviorType, Callback, Position, SpriteType};
+use crate::model::{BehaviorType, Callback, Position, SelectedSeed, SpriteType};
 use crate::resource_loader::ResourceKind;
 use crate::scene::PlantsChooser;
 use crate::sprite::{BehaviorManager, Sprite};
@@ -40,7 +40,30 @@ impl BattleScene {
         scroll.reverse(now, Callback::StartBattle);
     }
 
-    pub fn add_plant_card(game: &mut Game, seed_name: &str) -> String {
+    pub fn select_seed(game: &mut Game, seed_id: &String) -> String {
+        let seed = game.get_sprite_by_id(seed_id);
+        let seed_name = seed.name.clone();
+
+        seed.drawing_state.hover(true);
+
+        Self::add_plant_card(game, &seed_name)
+    }
+
+    pub fn deselect_seed(game: &mut Game, selected_seed: &SelectedSeed) {
+        let seed_sprite = game.get_sprite_by_id(&selected_seed.0);
+        seed_sprite.drawing_state.hover(false);
+
+        game.remove_sprites_by_id(vec![&selected_seed.1]);
+
+        Self::update_selected_cards_layout(game);
+    }
+
+    pub fn start(game: &mut Game) {
+        // TODO - Swap cards Callback to Plant action.
+        log!("Starting Battle Scene!");
+    }
+
+    fn add_plant_card(game: &mut Game, seed_name: &String) -> String {
         let current_cards = game.state.selected_seeds.len();
 
         let mut plant =
@@ -48,15 +71,15 @@ impl BattleScene {
 
         let plant_id = plant.id.clone();
 
-        plant.update_position(Position::new(60.0 * current_cards as f64, 0.0));
         plant.drawing_state.scale = 1.0;
+        plant.update_position(Position::new(60.0 * current_cards as f64, 0.0));
 
         game.add_sprite(plant);
 
         plant_id
     }
 
-    pub fn update_selected_cards_layout(game: &mut Game) {
+    fn update_selected_cards_layout(game: &mut Game) {
         let mut count = 0;
         let selected_seeds = &game.state.selected_seeds.to_vec();
 
@@ -66,11 +89,6 @@ impl BattleScene {
             card_sprite.update_position(Position::new(60.0 * count as f64, 0.0));
 
             count += 1;
-        })
-    }
-
-    pub fn start(game: &mut Game) {
-        // TODO - Swap cards Callback to Plant action.
-        log!("Starting Battle Scene!");
+        });
     }
 }

--- a/src/scene/battle.rs
+++ b/src/scene/battle.rs
@@ -15,12 +15,6 @@ impl BattleScene {
             &game.resources,
         );
 
-        let mut cards = Sprite::create_sprites(
-            vec!["SunFlower", "Peashooter"],
-            &ResourceKind::Card,
-            &game.resources,
-        );
-
         // TODO - Show Enemies (Zombies)
 
         // Trigger background scroll
@@ -32,7 +26,6 @@ impl BattleScene {
         );
 
         game.add_sprites(sprites.as_mut());
-        game.add_sprites(cards.as_mut());
     }
 
     pub fn enter(game: &mut Game) {

--- a/src/scene/battle.rs
+++ b/src/scene/battle.rs
@@ -42,6 +42,5 @@ impl BattleScene {
 
     pub fn start(game: &mut Game) {
         log!("Starting Battle Scene!");
-        todo!()
     }
 }

--- a/src/scene/plants_chooser.rs
+++ b/src/scene/plants_chooser.rs
@@ -1,6 +1,6 @@
 use crate::game::Game;
 use crate::log;
-use crate::model::{BehaviorType, Position};
+use crate::model::{BehaviorType, LevelData, Position};
 use crate::resource_loader::ResourceKind;
 use crate::sprite::{BehaviorManager, Sprite};
 
@@ -18,6 +18,7 @@ impl PlantsChooser {
             &game.resources,
         );
 
+        Self::build_cards_layout(game);
         Self::create_bottom_sun_score(game);
 
         game.add_sprites(sprites.as_mut());
@@ -28,6 +29,15 @@ impl PlantsChooser {
 
         scene_sprites.append(Self::chooser_sprites().as_mut());
 
+        let cards_clone = game.selected_level.plant_cards.clone();
+
+        let mut cards = cards_clone
+            .iter()
+            .map(|card| card.trim())
+            .collect::<Vec<&str>>();
+
+        scene_sprites.append(cards.as_mut());
+
         game.remove_sprites(scene_sprites);
     }
 
@@ -35,10 +45,26 @@ impl PlantsChooser {
         let mut sun_score =
             Sprite::create_sprite("SunScore", &ResourceKind::Interface, &game.resources).remove(0);
 
-        sun_score.position = Position::new(560.0, 138.0);
+        sun_score.position = Position::new(560.0, 98.0);
 
         // TODO - Dynamically bound Game sun score into this Sprite TextOverlay.
 
         game.add_sprite(sun_score);
+    }
+
+    fn build_cards_layout(game: &mut Game) {
+        let mut cards = game
+            .selected_level
+            .plant_cards
+            .iter()
+            .flat_map(|card_name| {
+                Sprite::create_sprite(card_name.trim(), &ResourceKind::Card, &game.resources)
+            })
+            .collect::<Vec<Sprite>>();
+
+        log!("Bulding cards {} ", cards.len());
+        // TODO - Iterate Cards and place it as a row layout inside the chooser.
+
+        game.add_sprites(cards.as_mut());
     }
 }

--- a/src/scene/plants_chooser.rs
+++ b/src/scene/plants_chooser.rs
@@ -1,9 +1,9 @@
 use crate::game::Game;
 use crate::location_builder::LocationBuilder;
 use crate::log;
-use crate::model::{BehaviorType, LevelData, Position, Size};
+use crate::model::{Position, Size, SpriteType};
 use crate::resource_loader::ResourceKind;
-use crate::sprite::{BehaviorManager, Sprite};
+use crate::sprite::Sprite;
 
 pub struct PlantsChooser;
 
@@ -28,18 +28,17 @@ impl PlantsChooser {
     }
 
     pub fn clear(game: &mut Game) {
-        let game_cards_clone = game.state.get_level().plant_cards.clone();
         let mut scene_sprites = vec!["SunScore"];
 
-        let mut cards = game_cards_clone
-            .iter()
-            .map(|card| card.trim())
-            .collect::<Vec<&str>>();
-
         scene_sprites.append(Self::chooser_sprites().as_mut());
-        scene_sprites.append(cards.as_mut());
 
-        game.remove_sprites(scene_sprites);
+        game.remove_sprites_by_name(scene_sprites);
+
+        game.remove_sprites_by_type(&SpriteType::Seed)
+    }
+
+    pub fn reset_selection(game: &mut Game) {
+        game.remove_sprites_by_type(&SpriteType::Card);
     }
 
     fn create_bottom_sun_score(game: &mut Game) {
@@ -74,6 +73,7 @@ impl PlantsChooser {
 
                 card_sprite.iter_mut().for_each(|card| {
                     card.update_position(positions[index]);
+                    card.sprite_type = SpriteType::Seed;
                 });
 
                 card_sprite

--- a/src/scene/plants_chooser.rs
+++ b/src/scene/plants_chooser.rs
@@ -29,15 +29,19 @@ impl PlantsChooser {
 
     pub fn clear(game: &mut Game) {
         let mut scene_sprites = vec!["SunScore"];
-
         scene_sprites.append(Self::chooser_sprites().as_mut());
 
         game.remove_sprites_by_name(scene_sprites);
-
         game.remove_sprites_by_type(&SpriteType::Seed)
     }
 
     pub fn reset_selection(game: &mut Game) {
+        game.get_sprites_by_type(&SpriteType::Seed)
+            .iter_mut()
+            .for_each(|seed| {
+                seed.drawing_state.hover(false);
+            });
+
         game.remove_sprites_by_type(&SpriteType::Card);
     }
 

--- a/src/scene/plants_chooser.rs
+++ b/src/scene/plants_chooser.rs
@@ -1,6 +1,5 @@
 use crate::game::Game;
 use crate::location_builder::LocationBuilder;
-use crate::log;
 use crate::model::{Position, Size, SpriteType};
 use crate::resource_loader::ResourceKind;
 use crate::sprite::Sprite;

--- a/src/scene/plants_chooser.rs
+++ b/src/scene/plants_chooser.rs
@@ -28,7 +28,7 @@ impl PlantsChooser {
     }
 
     pub fn clear(game: &mut Game) {
-        let game_cards_clone = game.selected_level.plant_cards.clone();
+        let game_cards_clone = game.state.get_level().plant_cards.clone();
         let mut scene_sprites = vec!["SunScore"];
 
         let mut cards = game_cards_clone
@@ -57,13 +57,14 @@ impl PlantsChooser {
         let card_scale = 0.725;
         let positions = LocationBuilder::create_row_layout(
             &Position::new(offset.top + 34.0, offset.left + 14.0),
-            game.selected_level.plant_cards.len(),
+            game.state.get_level().plant_cards.len(),
             6,
             Size::new(100.0 * card_scale, 60.0 * card_scale),
         );
 
         let mut cards = game
-            .selected_level
+            .state
+            .get_level()
             .plant_cards
             .iter()
             .enumerate()

--- a/src/scene/plants_chooser.rs
+++ b/src/scene/plants_chooser.rs
@@ -1,6 +1,7 @@
 use crate::game::Game;
+use crate::location_builder::LocationBuilder;
 use crate::log;
-use crate::model::{BehaviorType, LevelData, Position};
+use crate::model::{BehaviorType, LevelData, Position, Size};
 use crate::resource_loader::ResourceKind;
 use crate::sprite::{BehaviorManager, Sprite};
 
@@ -18,24 +19,24 @@ impl PlantsChooser {
             &game.resources,
         );
 
-        Self::build_cards_layout(game);
+        let chooser_background_offset = &sprites.first().unwrap().position;
+
+        Self::build_cards_layout(game, chooser_background_offset);
         Self::create_bottom_sun_score(game);
 
         game.add_sprites(sprites.as_mut());
     }
 
     pub fn clear(game: &mut Game) {
+        let game_cards_clone = game.selected_level.plant_cards.clone();
         let mut scene_sprites = vec!["SunScore"];
 
-        scene_sprites.append(Self::chooser_sprites().as_mut());
-
-        let cards_clone = game.selected_level.plant_cards.clone();
-
-        let mut cards = cards_clone
+        let mut cards = game_cards_clone
             .iter()
             .map(|card| card.trim())
             .collect::<Vec<&str>>();
 
+        scene_sprites.append(Self::chooser_sprites().as_mut());
         scene_sprites.append(cards.as_mut());
 
         game.remove_sprites(scene_sprites);
@@ -52,18 +53,31 @@ impl PlantsChooser {
         game.add_sprite(sun_score);
     }
 
-    fn build_cards_layout(game: &mut Game) {
+    fn build_cards_layout(game: &mut Game, offset: &Position) {
+        let card_scale = 0.725;
+        let positions = LocationBuilder::create_row_layout(
+            &Position::new(offset.top + 34.0, offset.left + 14.0),
+            game.selected_level.plant_cards.len(),
+            6,
+            Size::new(100.0 * card_scale, 60.0 * card_scale),
+        );
+
         let mut cards = game
             .selected_level
             .plant_cards
             .iter()
-            .flat_map(|card_name| {
-                Sprite::create_sprite(card_name.trim(), &ResourceKind::Card, &game.resources)
+            .enumerate()
+            .flat_map(|(index, card_name)| {
+                let mut card_sprite =
+                    Sprite::create_sprite(card_name.trim(), &ResourceKind::Card, &game.resources);
+
+                card_sprite.iter_mut().for_each(|card| {
+                    card.update_position(positions[index]);
+                });
+
+                card_sprite
             })
             .collect::<Vec<Sprite>>();
-
-        log!("Bulding cards {} ", cards.len());
-        // TODO - Iterate Cards and place it as a row layout inside the chooser.
 
         game.add_sprites(cards.as_mut());
     }

--- a/src/sprite/base.rs
+++ b/src/sprite/base.rs
@@ -64,7 +64,7 @@ impl Sprite {
             None => None,
         };
 
-        sprite.outlines = Outline::get_outlines(&sprite, exact_outlines);
+        sprite.update_outlines(exact_outlines);
 
         sprite
     }
@@ -78,6 +78,15 @@ impl Sprite {
             width: active_cell.width,
             height: active_cell.height,
         };
+    }
+
+    pub fn update_position(&mut self, position: Position) {
+        self.position = position;
+        self.update_outlines(false);
+    }
+
+    pub fn update_outlines(&mut self, exact_outlines: bool) {
+        self.outlines = Outline::get_outlines(&self, exact_outlines);
     }
 
     pub fn create_sprites(

--- a/src/sprite/base.rs
+++ b/src/sprite/base.rs
@@ -39,15 +39,16 @@ impl Sprite {
         text_overlay_data: &Option<TextOverlayData>,
         kind: ResourceKind,
     ) -> Sprite {
+        let id = uid(name);
         let sprite_behaviors = RefCell::new(
             behaviors
                 .iter()
-                .map(|behavior_data| BehaviorManager::create(&behavior_data))
+                .map(|behavior_data| BehaviorManager::create(&behavior_data, id.clone()))
                 .collect(),
         );
 
         let mut sprite = Sprite {
-            id: uid(name),
+            id,
             name: String::from(name),
             order,
             position,

--- a/src/sprite/base.rs
+++ b/src/sprite/base.rs
@@ -22,6 +22,7 @@ pub struct Sprite {
     pub image: Option<Weak<HtmlImageElement>>,
     pub drawing_state: DrawingState,
     pub text_overlay: Option<TextOverlay>,
+    pub kind: ResourceKind,
 }
 
 impl Sprite {
@@ -36,6 +37,7 @@ impl Sprite {
         behaviors: &Vec<BehaviorData>,
         exact_outlines: bool,
         text_overlay_data: &Option<TextOverlayData>,
+        kind: ResourceKind,
     ) -> Sprite {
         let sprite_behaviors = RefCell::new(
             behaviors
@@ -54,6 +56,7 @@ impl Sprite {
             outlines: vec![],
             behaviors: sprite_behaviors,
             text_overlay: None,
+            kind,
         };
 
         sprite.text_overlay = match text_overlay_data {
@@ -123,6 +126,7 @@ impl Sprite {
                     &behaviors,
                     exact_outlines,
                     &text_overlay,
+                    kind.clone(),
                 )
             })
             .collect()

--- a/src/sprite/base.rs
+++ b/src/sprite/base.rs
@@ -144,7 +144,6 @@ impl Sprite {
 
             if let Some(position) = mutation.position {
                 log!("TODO - Sprite position Changed");
-                todo!()
             }
         });
     }

--- a/src/sprite/base.rs
+++ b/src/sprite/base.rs
@@ -4,8 +4,7 @@ use std::rc::Weak;
 use js_sys::Math;
 use web_sys::HtmlImageElement;
 
-use crate::log;
-use crate::model::{BehaviorData, Position, SpriteCell, SpriteData, TextOverlayData};
+use crate::model::{BehaviorData, Position, SpriteCell, SpriteData, SpriteType, TextOverlayData};
 use crate::resource_loader::{Resource, ResourceKind, Resources};
 use crate::sprite::behavior::{Behavior, BehaviorManager};
 use crate::sprite::drawing_state::DrawingState;
@@ -22,7 +21,7 @@ pub struct Sprite {
     pub image: Option<Weak<HtmlImageElement>>,
     pub drawing_state: DrawingState,
     pub text_overlay: Option<TextOverlay>,
-    pub kind: ResourceKind,
+    pub sprite_type: SpriteType,
 }
 
 impl Sprite {
@@ -57,7 +56,7 @@ impl Sprite {
             outlines: vec![],
             behaviors: sprite_behaviors,
             text_overlay: None,
-            kind,
+            sprite_type: SpriteType::from_kind(&kind),
         };
 
         sprite.text_overlay = match text_overlay_data {

--- a/src/sprite/base.rs
+++ b/src/sprite/base.rs
@@ -156,7 +156,7 @@ impl Sprite {
             }
 
             if let Some(position) = mutation.position {
-                log!("TODO - Sprite position Changed");
+                self.update_position(position);
             }
         });
     }

--- a/src/sprite/behavior/base.rs
+++ b/src/sprite/behavior/base.rs
@@ -1,3 +1,5 @@
+use std::any::Any;
+
 use web_sys::CanvasRenderingContext2d;
 
 use crate::model::{BehaviorType, Callback, GameInteraction, Position};

--- a/src/sprite/behavior/base.rs
+++ b/src/sprite/behavior/base.rs
@@ -1,5 +1,3 @@
-use std::any::Any;
-
 use web_sys::CanvasRenderingContext2d;
 
 use crate::model::{BehaviorType, Callback, GameInteraction, Position};

--- a/src/sprite/behavior/base.rs
+++ b/src/sprite/behavior/base.rs
@@ -18,6 +18,8 @@ pub trait BehaviorState {
     }
 
     fn clean_interaction(&mut self);
+
+    fn set_sprite_id(&mut self, sprite_id: String);
 }
 
 pub trait Behavior: BehaviorState {

--- a/src/sprite/behavior/click.rs
+++ b/src/sprite/behavior/click.rs
@@ -30,7 +30,10 @@ impl Behavior for Click {
 
     fn get_interaction(&self) -> Option<GameInteraction> {
         if self.interaction_active {
-            return Some(GameInteraction::SpriteClick(self.callback));
+            return Some(GameInteraction::SpriteClick(
+                self.callback,
+                self.sprite_id.clone(),
+            ));
         }
 
         None

--- a/src/sprite/behavior/click.rs
+++ b/src/sprite/behavior/click.rs
@@ -10,7 +10,7 @@ use crate::sprite::{Sprite, SpriteMutation};
 #[derive(BaseBehavior, Default)]
 pub struct Click {
     name: BehaviorType,
-    callback: Callback,
+    pub callback: Callback,
 }
 
 impl Click {

--- a/src/sprite/behavior/mod.rs
+++ b/src/sprite/behavior/mod.rs
@@ -79,7 +79,10 @@ impl BehaviorManager {
             .get_mut()
             .iter_mut()
             .find(|sprite_behavior| behavior == sprite_behavior.name())
-            .expect(&format!("[BehaviorManager] Cannot find Sprite behavior: {:?}", behavior));
+            .expect(&format!(
+                "[BehaviorManager] Cannot find Sprite behavior: {:?}",
+                behavior
+            ));
 
         behavior
     }

--- a/src/sprite/behavior/mod.rs
+++ b/src/sprite/behavior/mod.rs
@@ -18,10 +18,10 @@ use crate::timers::GameTime;
 pub struct BehaviorManager;
 
 impl BehaviorManager {
-    pub fn create(data: &BehaviorData) -> Box<dyn Behavior> {
+    pub fn create(data: &BehaviorData, sprite_id: String) -> Box<dyn Behavior> {
         let behavior_type = BehaviorType::from_string(&data.name);
 
-        match behavior_type {
+        let mut behavior: Box<dyn Behavior> = match behavior_type {
             BehaviorType::Click => Box::new(Click::new(data.callback.unwrap())),
             BehaviorType::Animate => Box::new(Animate::new(
                 data.duration,
@@ -35,7 +35,11 @@ impl BehaviorManager {
                 data.duration,
                 data.callback.unwrap(),
             )),
-        }
+        };
+
+        behavior.set_sprite_id(sprite_id);
+
+        behavior
     }
 
     pub fn run(

--- a/src/sprite/behavior/scroll.rs
+++ b/src/sprite/behavior/scroll.rs
@@ -47,7 +47,6 @@ impl Behavior for Scroll {
     }
 
     fn reverse(&mut self, now: f64, callback: Callback) {
-        log!("Reversing scroll behavior nigga");
         self.direction *= -1;
         self.scrolled_distance = 0.0;
         self.callback = callback;

--- a/src/sprite/behavior/scroll.rs
+++ b/src/sprite/behavior/scroll.rs
@@ -2,7 +2,6 @@ use derives::{derive_behavior_fields, BaseBehavior};
 use web_sys::CanvasRenderingContext2d;
 
 use super::base::Behavior;
-use crate::log;
 use crate::model::{BehaviorType, Callback, GameInteraction, Position};
 use crate::sprite::{Sprite, SpriteMutation};
 

--- a/src/sprite/behavior/scroll.rs
+++ b/src/sprite/behavior/scroll.rs
@@ -40,7 +40,10 @@ impl Behavior for Scroll {
 
     fn get_interaction(&self) -> Option<GameInteraction> {
         if self.interaction_active {
-            return Some(GameInteraction::SpriteClick(self.callback));
+            return Some(GameInteraction::SpriteClick(
+                self.callback,
+                self.sprite_id.clone(),
+            ));
         }
 
         None


### PR DESCRIPTION
**Main changes**
- `PlantsChooser` scene now displays Cards within a row layout.
- Toggle cards selection: - Selecting seed disabling it, deselect is enabled click the card created.
- Start / Reset buttons functionality

**Side effects**
- `selected_level` added to the game.
- `update_position` with a `update_outlines` side effect helper added to `Sprite`.
- Saving `sprite_id` over behavior using derives.
- `Game` added Getters / Removers for `Sprite` entity (Potentially it should be all refactored to `SpriteSeachQuery`
- Added `SpriteType` instead of `kind` for better classifications.