### PR TITLE
Game Sun Score

### DIFF
--- a/assets/json/interface-data.json
+++ b/assets/json/interface-data.json
@@ -67,7 +67,7 @@
         "name": "Scroll",
         "callback": "ShowPlantsChooser",
         "distance": 335,
-        "rate": 18
+        "rate": 300
       }
     ],
     "order": 0
@@ -78,11 +78,11 @@
     "behaviors": [
       { "name": "Click", "callback": "CollectSun" },
       { "name": "Animate", "rate": 25,
-        "max_cycles": 10,
+        "max_cycles": 20,
         "callback": "RemoveSun",
         "callback_delay": 0
       },
-      { "name": "Walk", "velocity": {
+      { "name": "Walk", "distance": 250 ,"velocity": {
         "x": 0,
         "y": 20
       } }

--- a/assets/json/interface-data.json
+++ b/assets/json/interface-data.json
@@ -74,11 +74,14 @@
   },
   "Sun": {
     "constructor": "Sprite",
-    "position": [{ "left": 0, "top": 0 }],
+    "position": [{ "left": 100, "top": 100 }],
     "behaviors": [
-      { "name": "Cycle", "duration": 25 },
-      { "name": "Click" },
-      { "name": "Interval", "interval": 20000 }
+      { "name": "Click", "callback": "CollectSun" },
+      { "name": "Animate", "duration": 25,
+        "max_cycles": 10,
+        "callback": "RemoveSun",
+        "callback_delay": 0
+      }
     ],
     "order": 3
   },

--- a/assets/json/interface-data.json
+++ b/assets/json/interface-data.json
@@ -38,7 +38,7 @@
   "SelectorZombieHand": {
     "constructor": "Sprite",
     "position": [{ "left": 262, "top": 264 }],
-    "behaviors": [{ "name": "Animate", "duration": 120, "callback": "SelectLevel" }]
+    "behaviors": [{ "name": "Animate", "rate": 120, "callback": "SelectLevel" }]
   },
   "SelectorWoodSign1": {
     "constructor": "Sprite",
@@ -67,7 +67,7 @@
         "name": "Scroll",
         "callback": "ShowPlantsChooser",
         "distance": 335,
-        "duration": 18
+        "rate": 18
       }
     ],
     "order": 0
@@ -77,11 +77,15 @@
     "position": [{ "left": 100, "top": 100 }],
     "behaviors": [
       { "name": "Click", "callback": "CollectSun" },
-      { "name": "Animate", "duration": 25,
+      { "name": "Animate", "rate": 25,
         "max_cycles": 10,
         "callback": "RemoveSun",
         "callback_delay": 0
-      }
+      },
+      { "name": "Walk", "velocity": {
+        "x": 0,
+        "y": 20
+      } }
     ],
     "order": 3
   },

--- a/src/fps.rs
+++ b/src/fps.rs
@@ -5,7 +5,6 @@ pub struct Fps {
     current_time: f64,
     value: f64,
     display: u16,
-    last_animation_frame_time: f64,
     last_fps_update_time: f64,
 }
 
@@ -22,9 +21,9 @@ impl Fps {
         value as u16
     }
 
-    pub fn calc(&mut self, now: f64) {
+    pub fn calc(&mut self, now: f64, last_frame: f64) {
         self.current_time = now;
-        self.value = (1.0 / (now - self.last_animation_frame_time)) * 1000.0;
+        self.value = (1.0 / (now - last_frame)) * 1000.0;
 
         if now - self.last_fps_update_time > 1000.0 {
             self.last_fps_update_time = now;
@@ -32,9 +31,5 @@ impl Fps {
 
             log!("Game fps: {}", &self.display)
         }
-    }
-
-    pub fn set(&mut self, now: f64) {
-        self.last_animation_frame_time = now;
     }
 }

--- a/src/game.rs
+++ b/src/game.rs
@@ -114,15 +114,15 @@ impl Game {
             .iter()
             .for_each(|interaction| match interaction {
                 GameInteraction::SpriteClick(callback, sprite_id) => {
-                    self.interaction_callback(callback, Some(sprite_id))
+                    self.interaction_callback(callback, sprite_id)
                 }
-                GameInteraction::AnimationCallback(callback) => {
-                    self.interaction_callback(callback, None)
+                GameInteraction::AnimationCallback(callback, sprite_id) => {
+                    self.interaction_callback(callback, sprite_id)
                 }
             });
     }
 
-    pub fn interaction_callback(&mut self, callback: &Callback, sprite_id: Option<&String>) {
+    pub fn interaction_callback(&mut self, callback: &Callback, sprite_id: &String) {
         match callback {
             Callback::ShowZombieHand => self.show_zombie_hand_animation(),
             Callback::SelectLevel => self.select_level(),
@@ -131,8 +131,10 @@ impl Game {
             Callback::ResetPlantsChoose => self.reset_plants_choose(),
             Callback::EnterBattleAnimation => self.enter_battle_animation(),
             Callback::StartBattle => self.start_battle(),
-            Callback::ChooserSeedSelect => self.on_chooser_seed_click(sprite_id.unwrap()),
+            Callback::ChooserSeedSelect => self.on_chooser_seed_click(sprite_id),
             Callback::PlantCardClick => log!("Plant card click!!"),
+            Callback::CollectSun => self.collect_sun(sprite_id),
+            Callback::RemoveSun => self.remove_sun(sprite_id),
         }
     }
 
@@ -215,6 +217,17 @@ impl Game {
         }
 
         log!("After mutation {:?}", self.state.selected_seeds);
+    }
+
+    pub fn collect_sun(&mut self, sprite_id: &String) {
+        log!("COLLECTING SUN");
+        self.state.sun_state.add_score(50);
+
+        self.remove_sun(sprite_id);
+    }
+
+    pub fn remove_sun(&mut self, sprite_id: &String) {
+        self.remove_sprites_by_id(vec![sprite_id]);
     }
 
     // Game State Mutations //

--- a/src/game.rs
+++ b/src/game.rs
@@ -47,7 +47,9 @@ impl Game {
 
     pub fn run(&mut self) {
         let current_time = self.game_time.current_time();
-        self.fps.calc(current_time);
+        let last_frame = self.game_time.last_timestamp;
+
+        self.fps.calc(current_time, last_frame);
 
         // Draw game Sprites
         self.draw();
@@ -59,7 +61,7 @@ impl Game {
 
         SunManager::tick(self);
 
-        self.fps.set(current_time);
+        self.game_time.stamp();
     }
 
     fn draw(&mut self) {

--- a/src/game.rs
+++ b/src/game.rs
@@ -147,7 +147,7 @@ impl Game {
         self.reset_state();
 
         self.state.sun_state.enable_score(false);
-        self.state.sun_state.enable_sun(false);
+        self.state.sun_state.enable_sun(false, self.game_time.time);
 
         HomeScene::start(self);
     }
@@ -181,7 +181,7 @@ impl Game {
     }
 
     pub fn start_battle(&mut self) {
-        self.state.sun_state.enable_sun(true);
+        self.state.sun_state.enable_sun(true, self.game_time.time);
 
         BattleScene::start(self);
     }
@@ -215,12 +215,9 @@ impl Game {
                 .selected_seeds
                 .push((clicked_sprite_id.clone(), card_id));
         }
-
-        log!("After mutation {:?}", self.state.selected_seeds);
     }
 
     pub fn collect_sun(&mut self, sprite_id: &String) {
-        log!("COLLECTING SUN");
         self.state.sun_state.add_score(50);
 
         self.remove_sun(sprite_id);

--- a/src/game.rs
+++ b/src/game.rs
@@ -3,13 +3,13 @@ use web_sys::{HtmlCanvasElement, MouseEvent};
 use crate::fps::Fps;
 use crate::log;
 use crate::model::{
-    BehaviorType, Callback, GameInteraction, GameMouseEvent, GameState, Position,
-    SpriteType,
+    BehaviorType, Callback, GameInteraction, GameMouseEvent, GameState, Position, SpriteType,
 };
 use crate::painter::Painter;
-use crate::resource_loader::{Resources};
+use crate::resource_loader::Resources;
 use crate::scene::{BattleScene, HomeScene, PlantsChooser};
 use crate::sprite::{BehaviorManager, Sprite};
+use crate::sun_manager::SunManager;
 use crate::timers::GameTime;
 
 pub struct Game {
@@ -57,7 +57,7 @@ impl Game {
 
         // TODO - Handle Game internal sprites garbage collection Game::gc()
 
-        // TODO - SunGenerator::tick()
+        SunManager::tick(self);
 
         self.fps.set(current_time);
     }
@@ -79,6 +79,8 @@ impl Game {
 
             self.painter.draw_sprite(sprite);
         });
+
+        SunManager::update_sun_score(self);
     }
 
     // Canvas Mouse Events //
@@ -142,6 +144,9 @@ impl Game {
     fn start_home_scene(&mut self) {
         self.reset_state();
 
+        self.state.sun_state.enable_score(false);
+        self.state.sun_state.enable_sun(false);
+
         HomeScene::start(self);
     }
 
@@ -158,6 +163,8 @@ impl Game {
     }
 
     pub fn show_plants_chooser(&mut self) {
+        self.state.sun_state.enable_score(true);
+
         PlantsChooser::show(self);
     }
 
@@ -172,6 +179,8 @@ impl Game {
     }
 
     pub fn start_battle(&mut self) {
+        self.state.sun_state.enable_sun(true);
+
         BattleScene::start(self);
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ mod painter;
 mod resource_loader;
 mod scene;
 mod sprite;
+mod sun_manager;
 mod timers;
 mod web_utils;
 

--- a/src/location_builder.rs
+++ b/src/location_builder.rs
@@ -1,3 +1,5 @@
+use js_sys::Math;
+
 use crate::model::{LocationType, Position, Size};
 use crate::sprite::Sprite;
 
@@ -13,6 +15,20 @@ impl LocationBuilder {
             LocationType::Center => Self::place_at_center(sprite, item_dimensions),
             LocationType::Top => Self::place_at_top(sprite, item_dimensions),
         }
+    }
+
+    pub fn locate_sun() -> Position {
+        Position::new(
+            Self::rand_within_rand(0.0, 80.0),
+            Self::rand_within_rand(100.0, 750.0),
+        )
+    }
+
+    pub fn rand_within_rand(min: f64, max: f64) -> f64 {
+        let min = Math::ceil(min);
+        let max = Math::floor(max);
+
+        Math::floor(Math::random() * (max - min + 1.0)) + min
     }
 
     pub fn create_row_layout(

--- a/src/model.rs
+++ b/src/model.rs
@@ -140,6 +140,7 @@ pub enum BehaviorType {
     Click,
     Animate,
     Scroll,
+    Walk,
 }
 
 impl Default for BehaviorType {
@@ -155,20 +156,28 @@ impl BehaviorType {
             "Hover" => BehaviorType::Hover,
             "Animate" => BehaviorType::Animate,
             "Scroll" => BehaviorType::Scroll,
+            "Walk" => BehaviorType::Walk,
             _ => BehaviorType::default(),
         }
     }
+}
+
+#[derive(Debug, Default, Clone, Copy, Deserialize)]
+pub struct Velocity {
+    x: f64,
+    y: f64,
 }
 
 #[derive(Debug, Default, Clone, Deserialize)]
 #[serde(default)]
 pub struct BehaviorData {
     pub name: String,
-    pub duration: f64,
+    pub rate: f64,
     pub distance: f64,
     pub callback: Option<Callback>,
     pub callback_delay: Option<f64>,
     pub max_cycles: Option<usize>,
+    pub velocity: Option<Velocity>,
 }
 
 #[derive(Debug, Clone, Copy, Deserialize)]

--- a/src/model.rs
+++ b/src/model.rs
@@ -164,8 +164,8 @@ impl BehaviorType {
 
 #[derive(Debug, Default, Clone, Copy, Deserialize)]
 pub struct Velocity {
-    x: f64,
-    y: f64,
+    pub x: f64,
+    pub y: f64,
 }
 
 #[derive(Debug, Default, Clone, Deserialize)]

--- a/src/model.rs
+++ b/src/model.rs
@@ -4,12 +4,13 @@ use serde_derive::Deserialize;
 use web_sys::{MouseEvent, TextMetrics};
 
 use crate::resource_loader::ResourceKind;
+use crate::sun_manager::SunState;
 
 pub type SelectedSeed = (String, String);
 
 #[derive(Debug, Default)]
 pub struct GameState {
-    pub sun: usize,
+    pub sun_state: SunState,
     pub current_level: Option<LevelData>,
     pub selected_seeds: Vec<SelectedSeed>,
 }
@@ -17,7 +18,7 @@ pub struct GameState {
 impl GameState {
     pub fn new() -> GameState {
         GameState {
-            sun: 600,
+            sun_state: SunState::new(),
             current_level: None,
             selected_seeds: vec![],
         }
@@ -187,6 +188,7 @@ pub struct TextOverlayData {
     pub size: usize,
     pub offset: Option<Position>,
     pub location_type: LocationType,
+    pub color: Option<String>,
 }
 
 #[derive(Debug, Default, PartialEq, Clone, Copy, Deserialize)]

--- a/src/model.rs
+++ b/src/model.rs
@@ -58,6 +58,8 @@ pub enum Callback {
     StartBattle,
     ChooserSeedSelect,
     PlantCardClick,
+    RemoveSun,
+    CollectSun,
 }
 
 impl Default for Callback {
@@ -71,7 +73,7 @@ type SpriteId = String;
 #[derive(Debug)]
 pub enum GameInteraction {
     SpriteClick(Callback, SpriteId),
-    AnimationCallback(Callback),
+    AnimationCallback(Callback, SpriteId),
 }
 
 #[derive(Debug, Clone, Hash, Eq, PartialEq)]

--- a/src/painter.rs
+++ b/src/painter.rs
@@ -81,6 +81,10 @@ impl Painter {
         self.context.save();
         self.set_text_styles(text_overlay.size);
 
+        if let Some(color) = &text_overlay.color {
+            self.context.set_fill_style(&color.into());
+        }
+
         let position = &text_overlay.position.unwrap();
         let offset = &text_overlay.offset.unwrap_or(Position::default());
 

--- a/src/scene/battle.rs
+++ b/src/scene/battle.rs
@@ -59,6 +59,7 @@ impl BattleScene {
     }
 
     pub fn start(game: &mut Game) {
+        Self::draw_sun_score(game);
         // TODO - Swap cards Callback to Plant action.
         log!("Starting Battle Scene!");
     }
@@ -90,5 +91,12 @@ impl BattleScene {
 
             count += 1;
         });
+    }
+
+    fn draw_sun_score(game: &mut Game) {
+        let sun_score =
+            Sprite::create_sprite("SunScore", &ResourceKind::Interface, &game.resources).remove(0);
+
+        game.add_sprite(sun_score);
     }
 }

--- a/src/scene/plants_chooser.rs
+++ b/src/scene/plants_chooser.rs
@@ -20,7 +20,7 @@ impl PlantsChooser {
 
         let chooser_background_offset = &sprites.first().unwrap().position;
 
-        Self::build_cards_layout(game, chooser_background_offset);
+        Self::build_seeds_layout(game, chooser_background_offset);
         Self::create_bottom_sun_score(game);
 
         game.add_sprites(sprites.as_mut());
@@ -50,21 +50,19 @@ impl PlantsChooser {
 
         sun_score.position = Position::new(560.0, 98.0);
 
-        // TODO - Dynamically bound Game sun score into this Sprite TextOverlay.
-
         game.add_sprite(sun_score);
     }
 
-    fn build_cards_layout(game: &mut Game, offset: &Position) {
-        let card_scale = 0.725;
+    fn build_seeds_layout(game: &mut Game, offset: &Position) {
+        let seeds_scale = 0.725;
         let positions = LocationBuilder::create_row_layout(
             &Position::new(offset.top + 34.0, offset.left + 14.0),
             game.state.get_level().plant_cards.len(),
             6,
-            Size::new(100.0 * card_scale, 60.0 * card_scale),
+            Size::new(100.0 * seeds_scale, 60.0 * seeds_scale),
         );
 
-        let mut cards = game
+        let mut seeds = game
             .state
             .get_level()
             .plant_cards
@@ -83,6 +81,6 @@ impl PlantsChooser {
             })
             .collect::<Vec<Sprite>>();
 
-        game.add_sprites(cards.as_mut());
+        game.add_sprites(seeds.as_mut());
     }
 }

--- a/src/sprite/behavior/animate.rs
+++ b/src/sprite/behavior/animate.rs
@@ -45,7 +45,10 @@ impl Behavior for Animate {
             return None;
         }
 
-        return Some(GameInteraction::AnimationCallback(self.callback.unwrap()));
+        return Some(GameInteraction::AnimationCallback(
+            self.callback.unwrap(),
+            self.sprite_id.clone(),
+        ));
     }
 
     fn execute(

--- a/src/sprite/behavior/animate.rs
+++ b/src/sprite/behavior/animate.rs
@@ -10,7 +10,7 @@ use crate::sprite::{Sprite, SpriteMutation};
 pub struct Animate {
     name: BehaviorType,
     last_tick: f64,
-    duration: f64,
+    rate: f64,
     finished_cycles: usize,
     max_cycles: usize,
     callback: Option<Callback>,
@@ -19,14 +19,14 @@ pub struct Animate {
 
 impl Animate {
     pub fn new(
-        duration: f64,
+        rate: f64,
         callback: Option<Callback>,
         callback_delay: Option<f64>,
         max_cycles: Option<usize>,
     ) -> Animate {
         Animate {
             name: BehaviorType::Animate,
-            duration,
+            rate,
             callback,
             callback_delay: callback_delay.unwrap_or(1000.0),
             max_cycles: max_cycles.unwrap_or(1),
@@ -60,7 +60,7 @@ impl Behavior for Animate {
         _context: &CanvasRenderingContext2d,
     ) -> Option<SpriteMutation> {
         let finished = self.finished_cycles == self.max_cycles;
-        let should_animate = now - self.last_tick >= self.duration;
+        let should_animate = now - self.last_tick >= self.rate;
 
         if finished {
             let execute_callback = now - self.last_tick > self.callback_delay;

--- a/src/sprite/behavior/base.rs
+++ b/src/sprite/behavior/base.rs
@@ -31,6 +31,10 @@ pub trait Behavior: BehaviorState {
 
     fn reverse(&mut self, _now: f64, _callback: Callback) {}
 
+    fn animation_rate(&mut self, now: f64, last_frame: f64) -> f64 {
+        ((now - last_frame) / 1000.0)
+    }
+
     fn execute(
         &mut self,
         sprite: &Sprite,

--- a/src/sprite/behavior/mod.rs
+++ b/src/sprite/behavior/mod.rs
@@ -37,11 +37,7 @@ impl BehaviorManager {
                 data.rate,
                 data.callback.unwrap(),
             )),
-            BehaviorType::Walk => Box::new(Walk::new(
-                data.rate,
-                data.distance,
-                data.velocity.unwrap().clone(),
-            )),
+            BehaviorType::Walk => Box::new(Walk::new(data.distance, data.velocity.unwrap().clone())),
         };
 
         behavior.set_sprite_id(sprite_id);

--- a/src/sprite/behavior/mod.rs
+++ b/src/sprite/behavior/mod.rs
@@ -3,12 +3,14 @@ mod base;
 mod click;
 mod hover;
 mod scroll;
+mod walk;
 
 pub use animate::Animate;
 pub use base::Behavior;
 pub use click::Click;
 pub use hover::Hover;
 pub use scroll::Scroll;
+pub use walk::Walk;
 use web_sys::CanvasRenderingContext2d;
 
 use crate::model::{BehaviorData, BehaviorType, GameInteraction, Position};
@@ -24,7 +26,7 @@ impl BehaviorManager {
         let mut behavior: Box<dyn Behavior> = match behavior_type {
             BehaviorType::Click => Box::new(Click::new(data.callback.unwrap())),
             BehaviorType::Animate => Box::new(Animate::new(
-                data.duration,
+                data.rate,
                 data.callback,
                 data.callback_delay,
                 data.max_cycles,
@@ -32,8 +34,13 @@ impl BehaviorManager {
             BehaviorType::Hover => Box::new(Hover::new()),
             BehaviorType::Scroll => Box::new(Scroll::new(
                 data.distance,
-                data.duration,
+                data.rate,
                 data.callback.unwrap(),
+            )),
+            BehaviorType::Walk => Box::new(Walk::new(
+                data.rate,
+                data.distance,
+                data.velocity.unwrap().clone(),
             )),
         };
 

--- a/src/sprite/behavior/scroll.rs
+++ b/src/sprite/behavior/scroll.rs
@@ -13,17 +13,17 @@ pub struct Scroll {
     name: BehaviorType,
     callback: Callback,
     distance: f64,
-    duration: f64,
+    rate: f64,
     last_tick: f64,
     scrolled_distance: f64,
     direction: i32,
 }
 
 impl Scroll {
-    pub fn new(distance: f64, duration: f64, callback: Callback) -> Scroll {
+    pub fn new(distance: f64, rate: f64, callback: Callback) -> Scroll {
         Scroll {
             callback,
-            duration,
+            rate,
             distance,
             direction: 1,
             name: BehaviorType::Click,
@@ -67,7 +67,7 @@ impl Behavior for Scroll {
         _context: &CanvasRenderingContext2d,
     ) -> Option<SpriteMutation> {
         let finished = self.scrolled_distance.abs() >= self.distance;
-        let should_scroll = now - self.last_tick >= self.duration;
+        let should_scroll = now - self.last_tick >= self.rate; // TODO - Turn into relative movement (with addition)
 
         if finished {
             self.stop(now);
@@ -76,7 +76,6 @@ impl Behavior for Scroll {
             return None;
         }
 
-        // State will be preserved so we can tell if we directed.
         if should_scroll {
             let addition = SCROLL_ADDITION * self.direction as f64;
             self.last_tick = now;

--- a/src/sprite/behavior/walk.rs
+++ b/src/sprite/behavior/walk.rs
@@ -1,0 +1,50 @@
+use derives::{derive_behavior_fields, BaseBehavior};
+use web_sys::CanvasRenderingContext2d;
+
+use super::base::Behavior;
+use crate::log;
+use crate::model::{BehaviorType, Position, Velocity};
+use crate::sprite::{Sprite, SpriteMutation};
+
+#[derive_behavior_fields("")]
+#[derive(BaseBehavior, Default)]
+pub struct Walk {
+    name: BehaviorType,
+    velocity: Velocity,
+    rate: f64,
+    max_distance: f64,
+    walked_distance: f64,
+}
+
+impl Walk {
+    pub fn new(rate: f64, distance: f64, velocity: Velocity) -> Walk {
+        Walk {
+            name: BehaviorType::Walk,
+            rate,
+            velocity,
+            max_distance: distance,
+            ..Default::default()
+        }
+    }
+}
+
+impl Behavior for Walk {
+    fn name(&self) -> BehaviorType {
+        BehaviorType::Walk
+    }
+
+    fn execute(
+        &mut self,
+        sprite: &Sprite,
+        now: f64,
+        _last_frame: f64,
+        mouse: &Position,
+        context: &CanvasRenderingContext2d,
+    ) -> Option<SpriteMutation> {
+        self.stop(now);
+
+        log!("Running Walk Behavior {:?}", self.velocity);
+
+        None
+    }
+}

--- a/src/sprite/text_overlay.rs
+++ b/src/sprite/text_overlay.rs
@@ -10,6 +10,7 @@ pub struct TextOverlay {
     pub size: usize,
     pub position: Option<Position>,
     pub location_type: LocationType,
+    pub color: Option<String>,
 }
 
 impl TextOverlay {
@@ -20,6 +21,7 @@ impl TextOverlay {
             offset: data.offset,
             position: None,
             location_type: data.location_type,
+            color: data.color.clone(),
         };
 
         overlay.calculate_text_position(source_sprite);

--- a/src/sun_manager.rs
+++ b/src/sun_manager.rs
@@ -1,7 +1,7 @@
 use crate::game::Game;
 use crate::location_builder::LocationBuilder;
 use crate::log;
-use crate::model::{BehaviorType, Position, SpriteType, TextOverlayData};
+use crate::model::{BehaviorType, Position, TextOverlayData};
 use crate::resource_loader::ResourceKind;
 use crate::sprite::{BehaviorManager, Sprite, TextOverlay};
 
@@ -32,8 +32,9 @@ impl SunState {
         }
     }
 
-    pub fn enable_sun(&mut self, enabled: bool) {
+    pub fn enable_sun(&mut self, enabled: bool, now: f64) {
         self.features.generate_sun = enabled;
+        self.last_generated = now;
     }
 
     pub fn enable_score(&mut self, enabled: bool) {
@@ -56,8 +57,8 @@ impl SunManager {
             let should_generate = now - state.last_generated >= state.sun_interval;
 
             if should_generate {
-                log!("Generating SUN!"); // Create a random sun sprite
                 game.state.sun_state.last_generated = now;
+
                 Self::generate_random_sun(game);
             }
         }
@@ -83,7 +84,7 @@ impl SunManager {
                     size: 24,
                     offset: Some(Position::new(6.0, 14.0)),
                     location_type: Default::default(),
-                    color: Some(String::from("Black")),
+                    color: Some(String::from("black")),
                 },
                 &sun_score,
             ));
@@ -98,10 +99,9 @@ impl SunManager {
             .iter_mut()
             .for_each(|sprite| sprite.update_position(LocationBuilder::locate_sun()));
 
-        // TODO - Add `Walk` Behavior
         BehaviorManager::toggle_behaviors(
             &sun_sprite,
-            &[BehaviorType::Animate],
+            &[BehaviorType::Animate, BehaviorType::Walk],
             true,
             game.game_time.time,
         );

--- a/src/sun_manager.rs
+++ b/src/sun_manager.rs
@@ -1,0 +1,82 @@
+use crate::game::Game;
+use crate::log;
+use crate::model::{Position, SpriteType, TextOverlayData};
+use crate::sprite::{Sprite, TextOverlay};
+
+#[derive(Debug, Default)]
+pub struct Features {
+    pub update_score: bool,
+    pub generate_sun: bool,
+}
+
+#[derive(Debug, Default)]
+pub struct SunState {
+    pub last_generated: f64,
+    pub sun_interval: f64,
+    pub score: usize,
+    pub features: Features,
+}
+
+impl SunState {
+    pub fn new() -> Self {
+        SunState {
+            score: 600,
+            last_generated: 0.0,
+            sun_interval: 15.0 * 1000.0,
+            features: Features {
+                update_score: false,
+                generate_sun: false,
+            },
+        }
+    }
+
+    pub fn enable_sun(&mut self, enabled: bool) {
+        self.features.generate_sun = enabled;
+    }
+
+    pub fn enable_score(&mut self, enabled: bool) {
+        self.features.update_score = enabled;
+    }
+}
+
+pub struct SunManager;
+
+impl SunManager {
+    pub fn tick(game: &mut Game) {
+        let now = game.game_time.time;
+        let mut state = &game.state.sun_state;
+
+        if state.features.generate_sun {
+            let should_generate = now - state.last_generated >= state.sun_interval;
+
+            if should_generate {
+                log!("Generating SUN!");
+                game.state.sun_state.last_generated = now;
+            }
+        }
+    }
+
+    pub fn update_sun_score(game: &mut Game) {
+        let mut state = &game.state.sun_state;
+        let score = game.state.sun_state.score;
+
+        if !state.features.update_score {
+            return;
+        }
+
+        let sun_score = game.sprites.iter_mut().find(|sprite| sprite.name == "SunScore");
+
+        if let Some(sun_score) = sun_score {
+            sun_score.text_overlay = Some(TextOverlay::new(
+                &TextOverlayData {
+                    text: format!("{}", score),
+                    size: 24,
+                    offset: Some(Position::new(6.0, 14.0)),
+                    location_type: Default::default(),
+                    color: Some(String::from("Black")),
+                },
+                &sun_score,
+            ));
+        }
+    }
+}

--- a/src/sun_manager.rs
+++ b/src/sun_manager.rs
@@ -1,6 +1,5 @@
 use crate::game::Game;
 use crate::location_builder::LocationBuilder;
-use crate::log;
 use crate::model::{BehaviorType, Position, TextOverlayData};
 use crate::resource_loader::ResourceKind;
 use crate::sprite::{BehaviorManager, Sprite, TextOverlay};
@@ -24,7 +23,7 @@ impl SunState {
         SunState {
             score: 600,
             last_generated: 0.0,
-            sun_interval: 5.0 * 1000.0,
+            sun_interval: 15.0 * 1000.0,
             features: Features {
                 update_score: false,
                 generate_sun: false,

--- a/src/timers/game_time.rs
+++ b/src/timers/game_time.rs
@@ -27,11 +27,14 @@ impl GameTime {
 
         // Setting current time
         self.time = self.last_timestamp + elapsed;
-        self.last_timestamp = self.time;
 
         // Reset timer for next tick
         self.timer.reset(None);
 
         self.time
+    }
+
+    pub fn stamp(&mut self) {
+        self.last_timestamp = self.time;
     }
 }


### PR DESCRIPTION
**Main changes**
- Support `Sun` Generator / Score. - The generator generates 15 seconds of a random sun which drops to a constant location, and then disappears. If Sun was clicked, 50 points will be added to the game score.
- Added `Relative Game movement according to animation rate. Instead of checking if should perform tick of a given animation by a given duration, Changed to ease the given `rate` using the animation rate.

**Side effects**
- Removing `last_frame` from `FPS` entity, moved to `GameTime` sealed with a `stamp` method.