### PR TITLE
Plants Basic Shooting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,6 +39,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+
+[[package]]
 name = "futures"
 version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -128,6 +134,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -182,6 +197,7 @@ dependencies = [
  "console_error_panic_hook",
  "derives",
  "futures",
+ "itertools",
  "js-sys",
  "serde",
  "serde-wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ serde-wasm-bindgen = "0.4"
 wasm-bindgen = { version = "0.2.78", features = ["serde-serialize"] }
 wasm-bindgen-futures = "0.4.28"
 console_error_panic_hook = "0.1.7"
+itertools = "0.10.5"
 [dependencies.web-sys]
 version = "0.3.60"
 features = [

--- a/assets/json/level-data.json
+++ b/assets/json/level-data.json
@@ -12,7 +12,13 @@
       "TallNut"
     ],
     "zombies": [
-      "Buckethead"
+      "Buckethead",
+      "Conehead",
+      "ScreenDoor",
+      "Conehead",
+      "Conehead",
+      "Zombie1",
+      "Flag"
     ]
   }
 }

--- a/assets/json/level-data.json
+++ b/assets/json/level-data.json
@@ -12,13 +12,7 @@
       "TallNut"
     ],
     "zombies": [
-      "Buckethead",
-      "Conehead",
-      "ScreenDoor",
-      "Conehead",
-      "Conehead",
-      "Zombie1",
-      "Flag"
+      "Buckethead"
     ]
   }
 }

--- a/assets/json/plant-cell.json
+++ b/assets/json/plant-cell.json
@@ -470,14 +470,13 @@
     { "left": 2303, "top": 1206, "width": 79, "height": 58 },
     { "left": 2220, "top": 1273, "width": 79, "height": 58 }
   ],
-  "PB100": [{ "left": 2469, "top": 1816, "width": 56, "height": 34 }],
-  "PB00": [{ "left": 2299, "top": 3121, "width": 56, "height": 34 }],
-  "PB01": [{ "left": 2302, "top": 2999, "width": 56, "height": 34 }],
-  "PB10": [
+  "SnowBullet": [{ "left": 2469, "top": 1816, "width": 56, "height": 34 }],
+  "NormalBullet": [{ "left": 2299, "top": 3121, "width": 56, "height": 34 }],
+  "FireBullet": [
     { "left": 1050, "top": 1556, "width": 56, "height": 34 },
     { "left": 1175, "top": 754, "width": 56, "height": 34 }
   ],
-  "PB11": [
+  "ReverseFireBullet": [
     { "left": 1495, "top": 678, "width": 56, "height": 34 },
     { "left": 1293, "top": 718, "width": 56, "height": 34 }
   ],

--- a/assets/json/plant-data.json
+++ b/assets/json/plant-data.json
@@ -39,7 +39,8 @@
     "constructor": "PlantSprite",
     "position": [{ "left": 0, "top": 0 }],
     "behaviors": [
-      { "name": "Animate", "rate": 120, "max_cycles": 0 }
+      { "name": "Animate", "rate": 120, "max_cycles": 0 },
+      { "name": "Interval", "interval": 2000, "callback": "Shoot" }
     ]
   },
   "SnowBullet": {
@@ -47,11 +48,6 @@
     "position": [{ "left": 100, "top": 150 }],
     "behaviors": [
       { "name": "Animate", "rate": 120, "max_cycles": 0 },
-      {
-        "name": "Switch",
-        "switch_cells": ["PeaBulletHit", "FireBullet"],
-        "duration": 80
-      },
       { "name": "Walk", "velocity": { "x": 250, "y": 0 }}
     ],
     "collision_margin": { "left": 25, "top": 2, "right": 2, "bottom": 5 }
@@ -61,11 +57,6 @@
     "position": [{ "left": 100, "top": 250 }],
     "behaviors": [
       { "name": "Animate", "rate": 120, "max_cycles": 0 },
-      {
-        "name": "Switch",
-        "switch_cells": ["PeaBulletHit", "FireBullet"],
-        "duration": 80
-      },
       { "name": "Walk", "velocity": { "x": 200, "y": 0 }}
     ],
     "collision_margin": { "left": 25, "top": 2, "right": 2, "bottom": 5 }

--- a/assets/json/plant-data.json
+++ b/assets/json/plant-data.json
@@ -3,106 +3,88 @@
     "constructor": "PlantSprite",
     "position": [{ "left": 0, "top": 0 }],
     "behaviors": [
-      { "name": "Cycle", "duration": 120 },
-      { "name": "Interval", "interval": 2000 }
+      { "name": "Animate", "rate": 120, "max_cycles": 0 },
+      { "name": "Interval", "interval": 2000, "callback": "Shoot" }
     ]
   },
   "Torchwood": {
     "constructor": "PlantSprite",
     "position": [{ "left": 0, "top": 0 }],
-    "behaviors": [{ "name": "Cycle", "duration": 120 }]
+    "behaviors": [{ "name": "Animate", "rate": 120, "max_cycles": 0 }]
   },
   "WallNut": {
     "constructor": "PlantSprite",
     "position": [{ "left": 0, "top": 0 }],
-    "behaviors": [{ "name": "Cycle", "duration": 120 }]
+    "behaviors": [{ "name": "Animate", "rate": 120, "max_cycles": 0 }]
   },
   "TallNut": {
     "constructor": "PlantSprite",
     "position": [{ "left": 0, "top": 0 }],
-    "behaviors": [{ "name": "Cycle", "duration": 120 }]
+    "behaviors": [{ "name": "Animate", "rate": 120, "max_cycles": 0 }]
   },
   "PumpkinHead": {
     "constructor": "PlantSprite",
     "position": [{ "left": 0, "top": 0 }],
-    "behaviors": [{ "name": "Cycle", "duration": 120 }]
+    "behaviors": [{ "name": "Animate", "rate": 120, "max_cycles": 0 }]
   },
   "SunFlower": {
     "constructor": "PlantSprite",
     "position": [{ "left": 0, "top": 0 }],
     "behaviors": [
-      { "name": "Cycle", "duration": 100 },
-      { "name": "Interval", "interval": 7200 },
-      {
-        "name": "Switch",
-        "infinite": false,
-        "duration": 1800,
-        "switch_cells": ["SunFlower1"]
-      }
+      { "name": "Animate", "rate": 120, "max_cycles": 0 },
+      { "name": "Interval", "interval": 7200, "callback": "GenerateSunFlowSun" }
     ]
   },
   "SnowPea": {
     "constructor": "PlantSprite",
     "position": [{ "left": 0, "top": 0 }],
     "behaviors": [
-      { "name": "Cycle", "duration": 120 },
-      { "name": "Interval", "interval": 3000 }
+      { "name": "Animate", "rate": 120, "max_cycles": 0 }
     ]
   },
-  "PB100": {
+  "SnowBullet": {
     "constructor": "PlantSprite",
     "position": [{ "left": 100, "top": 150 }],
     "behaviors": [
-      { "name": "Cycle", "duration": 120 },
+      { "name": "Animate", "rate": 120, "max_cycles": 0 },
       {
         "name": "Switch",
-        "switch_cells": ["PeaBulletHit", "PB10"],
+        "switch_cells": ["PeaBulletHit", "FireBullet"],
         "duration": 80
       },
-      { "name": "Walk", "velocit": { "x": 250, "y": 0 }, "duration": 1000 },
-      { "name": "PlantCollision" }
+      { "name": "Walk", "velocity": { "x": 250, "y": 0 }}
     ],
     "collision_margin": { "left": 25, "top": 2, "right": 2, "bottom": 5 }
   },
-  "PB00": {
+  "NormalBullet": {
     "constructor": "PlantSprite",
     "position": [{ "left": 100, "top": 250 }],
     "behaviors": [
-      { "name": "Cycle", "duration": 120 },
+      { "name": "Animate", "rate": 120, "max_cycles": 0 },
       {
         "name": "Switch",
-        "switch_cells": ["PeaBulletHit", "PB10"],
+        "switch_cells": ["PeaBulletHit", "FireBullet"],
         "duration": 80
       },
-      { "name": "Walk", "velocit": { "x": 200, "y": 0 }, "duration": 1000 },
-      { "name": "PlantCollision" }
+      { "name": "Walk", "velocity": { "x": 200, "y": 0 }}
     ],
     "collision_margin": { "left": 25, "top": 2, "right": 2, "bottom": 5 }
   },
-  "PB01": {
-    "constructor": "PlantSprite",
-    "position": [{ "left": 100, "top": 350 }],
-    "behaviors": [
-      { "name": "Cycle", "duration": 120 },
-      { "name": "Walk", "velocit": { "x": -200, "y": 0 }, "duration": 1000 }
-    ],
-    "collision_margin": { "left": 2, "top": 2, "right": 25, "bottom": 5 }
-  },
-  "PB10": {
+  "FireBullet": {
     "constructor": "PlantSprite",
     "position": [{ "left": 100, "top": 450 }],
     "behaviors": [
-      { "name": "Cycle", "duration": 120 },
-      { "name": "Walk", "velocit": { "x": -200, "y": 0 }, "duration": 1000 }
+      { "name": "Animate", "rate": 120, "max_cycles": 0 },
+      { "name": "Walk", "velocity": { "x": -200, "y": 0 }}
     ],
     "collision_margin": { "left": 30, "top": 2, "right": 2, "bottom": 5 }
   },
-  "PB11": {
+  "ReverseFireBullet": {
     "constructor": "PlantSprite",
     "position": [{ "left": 100, "top": 550 }],
     "behaviors": [
-      { "name": "Cycle", "duration": 120 },
-      { "name": "Walk", "velocit": { "x": 200, "y": 0 }, "duration": 1000 }
+      { "name": "Animate", "rate": 120, "max_cycles": 0 },
+      { "name": "Walk", "velocity": { "x": 200, "y": 0 }}
     ],
     "collision_margin": { "left": 2, "top": 2, "right": 30, "bottom": 5 }
   }

--- a/assets/json/plant-data.json
+++ b/assets/json/plant-data.json
@@ -46,6 +46,7 @@
   "SnowBullet": {
     "constructor": "PlantSprite",
     "position": [{ "left": 100, "top": 150 }],
+    "damage": 25.0,
     "behaviors": [
       { "name": "Animate", "rate": 120, "max_cycles": 0 },
       { "name": "Walk", "velocity": { "x": 250, "y": 0 }},
@@ -54,6 +55,7 @@
   },
   "NormalBullet": {
     "constructor": "PlantSprite",
+    "damage": 25.0,
     "position": [{ "left": 100, "top": 250 }],
     "behaviors": [
       { "name": "Animate", "rate": 120, "max_cycles": 0 },
@@ -63,6 +65,7 @@
   },
   "FireBullet": {
     "constructor": "PlantSprite",
+    "damage": 35.0,
     "position": [{ "left": 100, "top": 450 }],
     "behaviors": [
       { "name": "Animate", "rate": 120, "max_cycles": 0 },
@@ -71,6 +74,7 @@
     ]
   },
   "ReverseFireBullet": {
+    "damage": 35.0,
     "constructor": "PlantSprite",
     "position": [{ "left": 100, "top": 550 }],
     "behaviors": [

--- a/assets/json/plant-data.json
+++ b/assets/json/plant-data.json
@@ -4,7 +4,7 @@
     "position": [{ "left": 0, "top": 0 }],
     "behaviors": [
       { "name": "Animate", "rate": 120, "max_cycles": 0 },
-      { "name": "Interval", "interval": 2000, "callback": "Shoot" }
+      { "name": "Interval", "interval": 3000, "callback": "Shoot" }
     ]
   },
   "Torchwood": {
@@ -40,7 +40,7 @@
     "position": [{ "left": 0, "top": 0 }],
     "behaviors": [
       { "name": "Animate", "rate": 120, "max_cycles": 0 },
-      { "name": "Interval", "interval": 2000, "callback": "Shoot" }
+      { "name": "Interval", "interval": 3000, "callback": "Shoot" }
     ]
   },
   "SnowBullet": {
@@ -48,35 +48,35 @@
     "position": [{ "left": 100, "top": 150 }],
     "behaviors": [
       { "name": "Animate", "rate": 120, "max_cycles": 0 },
-      { "name": "Walk", "velocity": { "x": 250, "y": 0 }}
-    ],
-    "collision_margin": { "left": 25, "top": 2, "right": 2, "bottom": 5 }
+      { "name": "Walk", "velocity": { "x": 250, "y": 0 }},
+      { "name": "Collision", "collision_margin": { "left": 25, "top": 2, "right": 2, "bottom": 5 }}
+    ]
   },
   "NormalBullet": {
     "constructor": "PlantSprite",
     "position": [{ "left": 100, "top": 250 }],
     "behaviors": [
       { "name": "Animate", "rate": 120, "max_cycles": 0 },
-      { "name": "Walk", "velocity": { "x": 200, "y": 0 }}
-    ],
-    "collision_margin": { "left": 25, "top": 2, "right": 2, "bottom": 5 }
+      { "name": "Walk", "velocity": { "x": 200, "y": 0 }},
+      { "name": "Collision", "collision_margin": { "left": 25, "top": 2, "right": 2, "bottom": 5 }}
+    ]
   },
   "FireBullet": {
     "constructor": "PlantSprite",
     "position": [{ "left": 100, "top": 450 }],
     "behaviors": [
       { "name": "Animate", "rate": 120, "max_cycles": 0 },
-      { "name": "Walk", "velocity": { "x": -200, "y": 0 }}
-    ],
-    "collision_margin": { "left": 30, "top": 2, "right": 2, "bottom": 5 }
+      { "name": "Walk", "velocity": { "x": -200, "y": 0 }},
+      { "name": "Collision", "collision_margin": { "left": 30, "top": 2, "right": 2, "bottom": 5 }}
+    ]
   },
   "ReverseFireBullet": {
     "constructor": "PlantSprite",
     "position": [{ "left": 100, "top": 550 }],
     "behaviors": [
       { "name": "Animate", "rate": 120, "max_cycles": 0 },
-      { "name": "Walk", "velocity": { "x": 200, "y": 0 }}
-    ],
-    "collision_margin": { "left": 2, "top": 2, "right": 30, "bottom": 5 }
+      { "name": "Walk", "velocity": { "x": 200, "y": 0 }},
+      { "name": "Collision", "collision_margin": { "left": 2, "top": 2, "right": 30, "bottom": 5 }}
+    ]
   }
 }

--- a/assets/json/plant-data.json
+++ b/assets/json/plant-data.json
@@ -46,6 +46,7 @@
   "SnowBullet": {
     "constructor": "PlantSprite",
     "position": [{ "left": 100, "top": 150 }],
+    "swap_cells": ["PeaBulletHit"],
     "damage": 25.0,
     "behaviors": [
       { "name": "Animate", "rate": 120, "max_cycles": 0 },
@@ -55,6 +56,7 @@
   },
   "NormalBullet": {
     "constructor": "PlantSprite",
+    "swap_cells": ["PeaBulletHit"],
     "damage": 25.0,
     "position": [{ "left": 100, "top": 250 }],
     "behaviors": [

--- a/assets/json/zombie-data.json
+++ b/assets/json/zombie-data.json
@@ -6,9 +6,9 @@
       { "name": "Animate", "rate": 120,
         "max_cycles": 0
       },
-      { "name": "Walk", "velocity": { "x": -10, "y": 0 } }
+      { "name": "Walk", "velocity": { "x": -10, "y": 0 } },
+      { "name": "Collision", "collision_margin": { "left": 30, "top": 5, "right": 10, "bottom": 5 }}
     ],
-    "collision_margin": { "left": 30, "top": 5, "right": 10, "bottom": 5 },
     "life": 200
   },
   "Buckethead": {
@@ -16,26 +16,27 @@
     "position": [{ "left": 0, "top": 0 }],
     "behaviors": [
       { "name": "Animate", "rate": 120, "max_cycles": 0 },
-      { "name": "Walk", "velocity": { "x": -9, "y": 0 } }
+      { "name": "Walk", "velocity": { "x": -9, "y": 0 } },
+      { "name": "Collision", "collision_margin": { "left": 30, "top": 5, "right": 10, "bottom": 5 }}
     ],
-    "life": 200,
-    "collision_margin": { "left": 30, "top": 5, "right": 10, "bottom": 5 }
+    "life": 200
   },
   "Flag": {
     "constructor": "Zombie",
     "position": [{ "left": 0, "top": 0 }],
     "behaviors": [
       { "name": "Animate", "rate": 120, "max_cycles": 0 },
-      { "name": "Walk", "velocity": { "x": -8, "y": 0 } }
-    ],
-    "collision_margin": { "left": 40, "top": 5, "right": 10, "bottom": 5 }
+      { "name": "Walk", "velocity": { "x": -8, "y": 0 } },
+      { "name": "Collision", "collision_margin": { "left": 40, "top": 5, "right": 10, "bottom": 5 }}
+    ]
   },
   "ScreenDoor": {
     "constructor": "Zombie",
     "position": [{ "left": 0, "top": 0 }],
     "behaviors": [
       { "name": "Animate", "rate": 120, "max_cycles": 0 },
-      { "name": "Walk", "velocity": { "x": -12, "y": 0 } }
+      { "name": "Walk", "velocity": { "x": -12, "y": 0 } },
+      { "name": "Collision" }
     ],
     "life": 200
   },
@@ -44,7 +45,8 @@
     "position": [{ "left": 0, "top": 0 }],
     "behaviors": [
       { "name": "Animate", "rate": 120, "max_cycles": 0 },
-      { "name": "Walk", "velocity": { "x": -5, "y": 0 } }
+      { "name": "Walk", "velocity": { "x": -5, "y": 0 } },
+      { "name": "Collision" }
     ]
   },
   "ZombieHead": {
@@ -56,16 +58,18 @@
         "name": "Walk",
         "velocit": { "x": 20, "y": -45 },
         "distance": 45
-      }
+      },
+      { "name": "Collision" }
     ],
-    "life": 0.0,
-    "collision_margin": { "left": 0, "top": 0, "right": 0, "bottom": 0 }
+    "life": 0.0
   },
   "ZombieDie": {
     "constructor": "Zombie",
     "position": [{ "left": 0, "top": 0 }],
-    "behaviors": [{ "name": "Animate", "rate": 120, "max_cycles": 0 }],
-    "life": 0.0,
-    "collision_margin": { "left": 0, "top": 0, "right": 0, "bottom": 0 }
+    "behaviors": [
+      { "name": "Animate", "rate": 120, "max_cycles": 0 },
+      { "name": "Collision" }
+    ],
+    "life": 0.0
   }
 }

--- a/assets/json/zombie-data.json
+++ b/assets/json/zombie-data.json
@@ -3,7 +3,7 @@
     "constructor": "Zombie",
     "position": [{ "left": 0, "top": 0 }],
     "behaviors": [
-      { "name": "Animate", "rate": 120,
+      { "name": "Animate", "rate": 160,
         "max_cycles": 0
       },
       { "name": "Walk", "velocity": { "x": -10, "y": 0 } },
@@ -15,7 +15,7 @@
     "constructor": "Zombie",
     "position": [{ "left": 0, "top": 0 }],
     "behaviors": [
-      { "name": "Animate", "rate": 120, "max_cycles": 0 },
+      { "name": "Animate", "rate": 160, "max_cycles": 0 },
       { "name": "Walk", "velocity": { "x": -9, "y": 0 } },
       { "name": "Collision", "collision_margin": { "left": 30, "top": 5, "right": 10, "bottom": 5 }}
     ],
@@ -25,7 +25,7 @@
     "constructor": "Zombie",
     "position": [{ "left": 0, "top": 0 }],
     "behaviors": [
-      { "name": "Animate", "rate": 120, "max_cycles": 0 },
+      { "name": "Animate", "rate": 160, "max_cycles": 0 },
       { "name": "Walk", "velocity": { "x": -8, "y": 0 } },
       { "name": "Collision", "collision_margin": { "left": 40, "top": 5, "right": 10, "bottom": 5 }}
     ]
@@ -34,7 +34,7 @@
     "constructor": "Zombie",
     "position": [{ "left": 0, "top": 0 }],
     "behaviors": [
-      { "name": "Animate", "rate": 120, "max_cycles": 0 },
+      { "name": "Animate", "rate": 160, "max_cycles": 0 },
       { "name": "Walk", "velocity": { "x": -12, "y": 0 } },
       { "name": "Collision" }
     ],
@@ -44,7 +44,7 @@
     "constructor": "Zombie",
     "position": [{ "left": 0, "top": 0 }],
     "behaviors": [
-      { "name": "Animate", "rate": 120, "max_cycles": 0 },
+      { "name": "Animate", "rate": 160, "max_cycles": 0 },
       { "name": "Walk", "velocity": { "x": -5, "y": 0 } },
       { "name": "Collision" }
     ]
@@ -67,7 +67,7 @@
     "constructor": "Zombie",
     "position": [{ "left": 0, "top": 0 }],
     "behaviors": [
-      { "name": "Animate", "rate": 120, "max_cycles": 0 },
+      { "name": "Animate", "rate": 160, "max_cycles": 0 },
       { "name": "Collision" }
     ],
     "life": 0.0

--- a/assets/json/zombie-data.json
+++ b/assets/json/zombie-data.json
@@ -3,9 +3,7 @@
     "constructor": "Zombie",
     "position": [{ "left": 0, "top": 0 }],
     "behaviors": [
-      { "name": "Animate", "rate": 160,
-        "max_cycles": 0
-      },
+      { "name": "Animate", "rate": 160, "max_cycles": 0 },
       { "name": "Walk", "velocity": { "x": -10, "y": 0 } },
       { "name": "Collision", "collision_margin": { "left": 30, "top": 5, "right": 10, "bottom": 5 }}
     ],

--- a/src/battle_manage.rs
+++ b/src/battle_manage.rs
@@ -1,0 +1,24 @@
+use itertools::Itertools;
+use crate::game::Game;
+use crate::log;
+use crate::model::SpriteType;
+use crate::resource_loader::ResourceKind;
+use crate::sprite::Sprite;
+
+pub struct BattleManager;
+
+impl BattleManager {
+    pub fn manage_fight(game: &mut Game) {
+        game.sprites
+            .iter_mut()
+            .sorted_by(|a, b| a.board_location.row.cmp(&b.board_location.row))
+            .filter(|sprite| sprite.sprite_type == SpriteType::Plant || sprite.sprite_type == SpriteType::Zombie) // TODO -Filter with has_collision
+            .group_by(|sprite| sprite.board_location.row)
+            .into_iter()
+            .map(|(_, items)| items.collect::<Vec<&mut Sprite>>())
+            .for_each(|group| {
+                //group.iter().for_each(|s| log!("Procssing {}", s.id))
+            });
+    }
+}
+

--- a/src/battle_manage.rs
+++ b/src/battle_manage.rs
@@ -2,22 +2,69 @@ use itertools::Itertools;
 
 use crate::game::Game;
 use crate::log;
-use crate::model::SpriteType;
+use crate::model::{BehaviorType, SpriteType};
 use crate::sprite::Sprite;
 
 pub struct BattleManager;
 
+// Activate their `on_collision` hook
+// Manage fight life
+
 impl BattleManager {
     pub fn manage_fight(game: &mut Game) {
         game.sprites
-            .iter_mut()
+            .iter()
             .sorted_by(|a, b| a.board_location.row.cmp(&b.board_location.row))
-            .filter(|sprite| {
-                sprite.sprite_type == SpriteType::Bullet || sprite.sprite_type == SpriteType::Zombie
-            }) // TODO -Filter with has_collision
+            .filter(|sprite| Self::has_collision_behavior(sprite))
             .group_by(|sprite| sprite.board_location.row)
             .into_iter()
-            .map(|(_, items)| items.collect::<Vec<&mut Sprite>>())
-            .for_each(|group| group.iter().for_each(|s| log!("Procssing {}", s.id)));
+            .map(|(_, items)| items.collect::<Vec<&Sprite>>())
+            .for_each(|group| {
+                let others = group.to_vec();
+
+                group.into_iter().for_each(|sprite| {
+                    // For each given sprite within the group, finding respective collision candidates
+                    let candidates = others.iter()
+                        .filter(|other| Self::can_collide(sprite, other))
+                        .collect::<Vec<&&Sprite>>();
+
+                    // For each candidate, Check if collided
+                    let collided_candidate = candidates.iter()
+                        .find(|candidate| Self::has_collision(sprite, candidate));
+
+
+                    log!("Procssing {} / {} ", sprite.id, candidates.len());
+
+                    if let Some(collided_sprite) = collided_candidate {
+                        log!("Found collided Sprite {}", collided_sprite.id)
+                    }
+                });
+            });
     }
+
+    fn has_collision_behavior(sprite: &&Sprite) -> bool {
+        let behaviors = sprite.behaviors.borrow();
+
+        behaviors
+            .iter()
+            .find(|sprite_behavior| BehaviorType::Collision == sprite_behavior.name())
+            .is_some()
+    }
+
+    fn can_collide(sprite: &Sprite, other: &Sprite) -> bool {
+        let source_type = &sprite.sprite_type;
+
+        let target_type = match source_type {
+            SpriteType::Zombie => SpriteType::Plant,
+            SpriteType::Bullet => SpriteType::Zombie,
+            _ => SpriteType::Meta
+        };
+
+        &target_type == &other.sprite_type
+    }
+
+    fn has_collision(sprite: &Sprite, other: &Sprite) -> bool {
+        false
+    }
+
 }

--- a/src/battle_manage.rs
+++ b/src/battle_manage.rs
@@ -1,8 +1,8 @@
 use itertools::Itertools;
+
 use crate::game::Game;
 use crate::log;
 use crate::model::SpriteType;
-use crate::resource_loader::ResourceKind;
 use crate::sprite::Sprite;
 
 pub struct BattleManager;
@@ -12,13 +12,12 @@ impl BattleManager {
         game.sprites
             .iter_mut()
             .sorted_by(|a, b| a.board_location.row.cmp(&b.board_location.row))
-            .filter(|sprite| sprite.sprite_type == SpriteType::Plant || sprite.sprite_type == SpriteType::Zombie) // TODO -Filter with has_collision
+            .filter(|sprite| {
+                sprite.sprite_type == SpriteType::Bullet || sprite.sprite_type == SpriteType::Zombie
+            }) // TODO -Filter with has_collision
             .group_by(|sprite| sprite.board_location.row)
             .into_iter()
             .map(|(_, items)| items.collect::<Vec<&mut Sprite>>())
-            .for_each(|group| {
-                //group.iter().for_each(|s| log!("Procssing {}", s.id))
-            });
+            .for_each(|group| group.iter().for_each(|s| log!("Procssing {}", s.id)));
     }
 }
-

--- a/src/battle_manage.rs
+++ b/src/battle_manage.rs
@@ -7,11 +7,45 @@ use crate::sprite::Sprite;
 
 pub struct BattleManager;
 
+struct CollisionMutation {
+    target_id: String,
+    life_deduction: Option<usize>,
+}
+
+impl CollisionMutation {
+    pub fn new(id: &String) -> Self {
+        CollisionMutation {
+            target_id: String::from(id),
+            life_deduction: None,
+        }
+    }
+}
+
 // Activate their `on_collision` hook
 // Manage fight life
 
 impl BattleManager {
     pub fn manage_fight(game: &mut Game) {
+        let mut mutations = Self::collect_collision_mutations(game);
+
+        game.sprites.iter_mut().for_each(|sprite| {
+            let mutation = mutations
+                .iter()
+                .find(|mutation| mutation.target_id == sprite.id);
+
+            if let Some(mutation) = mutation {
+                log!("Activation mutation! on {}", mutation.target_id)
+
+                // Apply sprite mutation
+
+                // Trigger on_collide?
+            }
+        });
+    }
+
+    fn collect_collision_mutations(game: &mut Game) -> Vec<CollisionMutation> {
+        let mut mutations: Vec<CollisionMutation> = vec![];
+
         game.sprites
             .iter()
             .sorted_by(|a, b| a.board_location.row.cmp(&b.board_location.row))
@@ -24,22 +58,23 @@ impl BattleManager {
 
                 group.into_iter().for_each(|sprite| {
                     // For each given sprite within the group, finding respective collision candidates
-                    let candidates = others.iter()
+                    let candidates = others
+                        .iter()
                         .filter(|other| Self::can_collide(sprite, other))
                         .collect::<Vec<&&Sprite>>();
 
                     // For each candidate, Check if collided
-                    let collided_candidate = candidates.iter()
+                    let collided_candidate = candidates
+                        .iter()
                         .find(|candidate| Self::has_collision(sprite, candidate));
 
-
-                    log!("Procssing {} / {} ", sprite.id, candidates.len());
-
                     if let Some(collided_sprite) = collided_candidate {
-                        log!("Found collided Sprite {}", collided_sprite.id)
+                        mutations.push(CollisionMutation::new(&collided_sprite.id));
                     }
                 });
             });
+
+        mutations
     }
 
     fn has_collision_behavior(sprite: &&Sprite) -> bool {
@@ -57,14 +92,14 @@ impl BattleManager {
         let target_type = match source_type {
             SpriteType::Zombie => SpriteType::Plant,
             SpriteType::Bullet => SpriteType::Zombie,
-            _ => SpriteType::Meta
+            _ => SpriteType::Meta,
         };
 
         &target_type == &other.sprite_type
     }
 
     fn has_collision(sprite: &Sprite, other: &Sprite) -> bool {
-        false
+        // TODO - Make it real
+        sprite.position.left > other.position.left
     }
-
 }

--- a/src/board.rs
+++ b/src/board.rs
@@ -1,6 +1,8 @@
+use crate::constants::{CANVAS_HEIGHT_F64, CANVAS_WIDTH_F64};
 use crate::features::GameFeatures;
 use crate::game::Game;
 use crate::model::{Dimensions, Position, SpriteCell};
+use crate::sprite::{DrawingState, Sprite};
 
 #[derive(Debug, Clone, Copy)]
 pub struct BoardLocation {
@@ -86,5 +88,14 @@ impl Board {
         let location = Self::get_board_location(position);
 
         location.col > 1 && location.col <= 9 && location.row > 0 && location.row <= 5
+    }
+
+    pub fn is_out_of_board(sprite: &Sprite, position: &Position) -> bool {
+        let cell = DrawingState::get_active_cell(sprite);
+
+        position.top < 0.0
+            || position.left < 0.0
+            || position.left + cell.width > CANVAS_WIDTH_F64
+            || position.top + cell.height > CANVAS_HEIGHT_F64
     }
 }

--- a/src/board.rs
+++ b/src/board.rs
@@ -2,7 +2,7 @@ use crate::features::GameFeatures;
 use crate::game::Game;
 use crate::model::{Dimensions, Position, SpriteCell};
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub struct BoardLocation {
     pub row: usize,
     pub col: usize,

--- a/src/game.rs
+++ b/src/game.rs
@@ -219,7 +219,6 @@ impl Game {
 
     pub fn start_battle(&mut self) {
         GameFeatures::enable_generate_sun(true);
-
         BattleScene::start(self);
     }
 

--- a/src/game.rs
+++ b/src/game.rs
@@ -25,6 +25,7 @@ pub struct Game {
     fps: Fps,
 
     last_gc: f64,
+    internal_once: bool,
 }
 
 impl Game {
@@ -38,6 +39,7 @@ impl Game {
             mouse_position: Position::new(0.0, 0.0),
             sprites: vec![],
             last_gc: 0.0,
+            internal_once: false,
         }
     }
 
@@ -181,6 +183,8 @@ impl Game {
     }
 
     fn start_home_scene(&mut self) {
+        self.toggle_game_behavior(false, &[BehaviorType::Collision]);
+
         self.reset_state();
 
         GameFeatures::enable_update_sun_score(false);
@@ -303,6 +307,10 @@ impl Game {
     }
 
     pub fn on_plant_shoot(&mut self, sprite_id: &String) {
+        if self.internal_once {
+            return;
+        }
+
         let shooting_plant_location = &self.get_sprite_by_id(sprite_id).board_location.clone();
 
         // Check if row contains an enemy

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ mod sprite;
 mod sun_manager;
 mod timers;
 mod web_utils;
+mod battle_manage;
 
 #[wasm_bindgen(start)]
 pub fn run() -> Result<(), JsValue> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ use engine::Engine;
 use wasm_bindgen::prelude::*;
 use web_utils::bind_panic_logger;
 
+mod battle_manage;
 mod board;
 mod constants;
 mod engine;
@@ -17,7 +18,6 @@ mod sprite;
 mod sun_manager;
 mod timers;
 mod web_utils;
-mod battle_manage;
 
 #[wasm_bindgen(start)]
 pub fn run() -> Result<(), JsValue> {

--- a/src/location_builder.rs
+++ b/src/location_builder.rs
@@ -31,6 +31,10 @@ impl LocationBuilder {
         Board::get_board_placement(plant_cell, location.row, location.col)
     }
 
+    pub fn bullet_location(plant_position: &Position) -> Position {
+        Position::new(plant_position.top + 6.0, plant_position.left + 20.0)
+    }
+
     pub fn zombie_location(zombie_cell: &SpriteCell, row: usize) -> Position {
         let start_col = 10;
         let start_row = ((row) % 5) + 1;

--- a/src/model.rs
+++ b/src/model.rs
@@ -145,7 +145,10 @@ pub struct SpriteData {
     pub order: usize,
     pub scale: f64,
     pub exact_outlines: bool,
+    pub life: f64,
+    pub damage: f64,
     pub draw_offset: Position,
+    pub swap_cells: Vec<String>,
     pub behaviors: Vec<BehaviorData>,
     pub text_overlay: Option<TextOverlayData>,
 }
@@ -157,8 +160,11 @@ impl Default for SpriteData {
             draw_offset: Position::default(),
             order: 1,
             scale: 1.0,
+            life: 100.0,
+            damage: 0.0,
             exact_outlines: false,
             behaviors: vec![],
+            swap_cells: vec![],
             text_overlay: None,
         }
     }

--- a/src/model.rs
+++ b/src/model.rs
@@ -82,6 +82,29 @@ pub enum GameInteraction {
     AnimationCallback(Callback, SpriteId),
 }
 
+#[derive(Debug)]
+pub enum Plant {
+    PeaShooter,
+    SnowPea
+}
+
+impl Plant {
+    pub fn from_name(name: &str) -> Plant {
+        match name {
+            "PeaShooter" => Plant::PeaShooter,
+            "SnowPea" => Plant::SnowPea,
+            _ => Plant::PeaShooter
+        }
+    }
+
+    pub fn bullet_type(plant: &Plant) -> &str {
+        match plant {
+            Plant::PeaShooter => "NormalBullet",
+            Plant::SnowPea => "SnowBullet"
+        }
+    }
+}
+
 #[derive(Debug, Clone, Hash, Eq, PartialEq)]
 pub enum SpriteType {
     Zombie,

--- a/src/model.rs
+++ b/src/model.rs
@@ -64,6 +64,8 @@ pub enum Callback {
     Plant,
     AllowShovelDrag,
     ShovelDragEnd,
+    Shoot,
+    GenerateSunFlowSun,
 }
 
 impl Default for Callback {
@@ -146,6 +148,7 @@ pub enum BehaviorType {
     Scroll,
     Walk,
     Drag,
+    Interval,
 }
 
 impl Default for BehaviorType {
@@ -163,6 +166,7 @@ impl BehaviorType {
             "Scroll" => BehaviorType::Scroll,
             "Walk" => BehaviorType::Walk,
             "Drag" => BehaviorType::Drag,
+            "Interval" => BehaviorType::Interval,
             _ => BehaviorType::default(),
         }
     }
@@ -184,6 +188,7 @@ pub struct BehaviorData {
     pub callback_delay: Option<f64>,
     pub max_cycles: Option<usize>,
     pub velocity: Option<Velocity>,
+    pub interval: Option<f64>,
 }
 
 impl BehaviorData {

--- a/src/model.rs
+++ b/src/model.rs
@@ -173,6 +173,7 @@ pub enum BehaviorType {
     Walk,
     Drag,
     Interval,
+    Collision,
 }
 
 impl Default for BehaviorType {
@@ -191,6 +192,7 @@ impl BehaviorType {
             "Walk" => BehaviorType::Walk,
             "Drag" => BehaviorType::Drag,
             "Interval" => BehaviorType::Interval,
+            "Collision" => BehaviorType::Collision,
             _ => BehaviorType::default(),
         }
     }
@@ -200,6 +202,14 @@ impl BehaviorType {
 pub struct Velocity {
     pub x: f64,
     pub y: f64,
+}
+
+#[derive(Debug, Default, Clone, Copy, Deserialize)]
+pub struct CollisionMargin {
+    pub left: usize,
+    pub right: usize,
+    pub top: usize,
+    pub bottom: usize,
 }
 
 #[derive(Debug, Default, Clone, Deserialize)]
@@ -213,6 +223,7 @@ pub struct BehaviorData {
     pub max_cycles: Option<usize>,
     pub velocity: Option<Velocity>,
     pub interval: Option<f64>,
+    pub collision_margin: Option<CollisionMargin>,
 }
 
 impl BehaviorData {

--- a/src/model.rs
+++ b/src/model.rs
@@ -85,7 +85,7 @@ pub enum GameInteraction {
 #[derive(Debug)]
 pub enum Plant {
     PeaShooter,
-    SnowPea
+    SnowPea,
 }
 
 impl Plant {
@@ -93,14 +93,14 @@ impl Plant {
         match name {
             "PeaShooter" => Plant::PeaShooter,
             "SnowPea" => Plant::SnowPea,
-            _ => Plant::PeaShooter
+            _ => Plant::PeaShooter,
         }
     }
 
     pub fn bullet_type(plant: &Plant) -> &str {
         match plant {
             Plant::PeaShooter => "NormalBullet",
-            Plant::SnowPea => "SnowBullet"
+            Plant::SnowPea => "SnowBullet",
         }
     }
 }
@@ -112,6 +112,7 @@ pub enum SpriteType {
     Interface,
     Card,
     Seed,
+    Bullet,
     Meta,
 }
 

--- a/src/painter.rs
+++ b/src/painter.rs
@@ -40,6 +40,7 @@ impl Painter {
                 &sprite.drawing_state.offset,
                 cell,
                 sprite.drawing_state.scale,
+                sprite.drawing_state.alpha,
             );
         }
 
@@ -55,9 +56,11 @@ impl Painter {
         offset: &Position,
         cell: &SpriteCell,
         scale: f64,
+        alpha: f64,
     ) {
         // Setting translate if defined, which will cause a "partial image" view.
         self.context.translate(-offset.left, -offset.top).unwrap();
+        self.context.set_global_alpha(alpha);
 
         self.context
             .draw_image_with_html_image_element_and_sw_and_sh_and_dx_and_dy_and_dw_and_dh(

--- a/src/resource_loader/mod.rs
+++ b/src/resource_loader/mod.rs
@@ -42,7 +42,6 @@ impl Resources {
         }
     }
 
-    // TODO - Consider cases which don't have the full data - Move to unwrap_or_else?
     pub fn get_resource(&self, name: &str, kind: &ResourceKind) -> Resource {
         let resource_key = format!("{}/{}", kind.value(), name);
 
@@ -61,10 +60,23 @@ impl Resources {
         }
     }
 
+    pub fn get_cell(&self, name: &str, kind: &ResourceKind) -> Vec<SpriteCell> {
+        let resource_key = format!("{}/{}", kind.value(), name);
+        let cells = self.cells.get(&resource_key);
+
+        match cells {
+            None => vec![],
+            Some(cells) => cells.to_vec(),
+        }
+    }
+
     pub fn get_level_data(&self, level_id: &str) -> LevelData {
         let resource_key = format!("{}/{}", ResourceKind::Level.value(), level_id);
 
-        let level_data = self.level_data.get(&resource_key).unwrap();
+        let level_data = self.level_data.get(&resource_key).expect(&format!(
+            "Level data is expected to be preset {}",
+            resource_key
+        ));
 
         level_data.clone()
     }

--- a/src/scene/battle.rs
+++ b/src/scene/battle.rs
@@ -113,6 +113,8 @@ impl BattleScene {
 
         Self::swap_plant_cards_action(game);
 
+        game.toggle_game_behavior(true, &[BehaviorType::Collision]);
+
         game.add_sprites(scene_sprites.as_mut());
     }
 
@@ -162,7 +164,11 @@ impl BattleScene {
 
         BehaviorManager::toggle_sprite_behaviors(
             &sprite,
-            &[BehaviorType::Animate, BehaviorType::Interval],
+            &[
+                BehaviorType::Animate,
+                BehaviorType::Interval,
+                BehaviorType::Collision,
+            ],
             true,
             now,
         );
@@ -188,7 +194,11 @@ impl BattleScene {
 
         BehaviorManager::toggle_sprite_behaviors(
             &bullet,
-            &[BehaviorType::Animate, BehaviorType::Walk],
+            &[
+                BehaviorType::Animate,
+                BehaviorType::Walk,
+                BehaviorType::Collision,
+            ],
             true,
             now,
         );

--- a/src/scene/battle.rs
+++ b/src/scene/battle.rs
@@ -1,3 +1,4 @@
+use crate::board::Board;
 use crate::game::Game;
 use crate::location_builder::LocationBuilder;
 use crate::log;
@@ -183,7 +184,7 @@ impl BattleScene {
 
         bullet.sprite_type = SpriteType::Bullet;
 
-        bullet.update_position(Position::new(position.top + 6.0, position.left + 20.0));
+        bullet.update_position(LocationBuilder::bullet_location(&position));
 
         BehaviorManager::toggle_sprite_behaviors(
             &bullet,

--- a/src/scene/battle.rs
+++ b/src/scene/battle.rs
@@ -149,6 +149,27 @@ impl BattleScene {
         game.add_sprite(plant);
     }
 
+    pub fn create_plant(game: &mut Game, sprite_id: &String) {
+        let now = game.game_time.time;
+        let mouse = game.mouse_position.clone();
+        let sprite = game.get_sprite_by_id(sprite_id);
+        let plant_cell = DrawingState::get_active_cell(&sprite);
+
+        // Clamp Plant sprite into closest cell bottom position.
+        let plant_position = LocationBuilder::plant_location(plant_cell, &mouse);
+        sprite.update_position(plant_position);
+
+        BehaviorManager::toggle_sprite_behaviors(
+            &sprite,
+            &[BehaviorType::Animate, BehaviorType::Interval],
+            true,
+            now,
+        );
+
+        // Resets drag top drawing order
+        sprite.order = 3; // TODO, Drag order based on behavior?
+    }
+
     pub fn allow_shovel_drag(game: &mut Game) {
         let now = game.game_time.time;
         let shovel_sprite = game.get_sprite_by_name_and_type("Shovel", &SpriteType::Interface);

--- a/src/scene/battle.rs
+++ b/src/scene/battle.rs
@@ -1,7 +1,5 @@
-use crate::board::Board;
 use crate::game::Game;
 use crate::location_builder::LocationBuilder;
-use crate::log;
 use crate::model::Callback::PlantCardClick;
 use crate::model::{BehaviorData, BehaviorType, Callback, Plant, Position, SelectedSeed, SpriteType};
 use crate::resource_loader::ResourceKind;

--- a/src/scene/battle.rs
+++ b/src/scene/battle.rs
@@ -2,7 +2,7 @@ use crate::game::Game;
 use crate::location_builder::LocationBuilder;
 use crate::log;
 use crate::model::Callback::PlantCardClick;
-use crate::model::{BehaviorData, BehaviorType, Callback, Position, SelectedSeed, SpriteType};
+use crate::model::{BehaviorData, BehaviorType, Callback, Plant, Position, SelectedSeed, SpriteType};
 use crate::resource_loader::ResourceKind;
 use crate::scene::PlantsChooser;
 use crate::sprite::{BehaviorManager, Click, DrawingState, Scroll, Sprite};
@@ -168,6 +168,35 @@ impl BattleScene {
 
         // Resets drag top drawing order
         sprite.order = 3; // TODO, Drag order based on behavior?
+    }
+
+    pub fn create_bullet(game: &mut Game, sprite_id : &String) {
+        let now = game.game_time.time;
+        let shooting_plant = game.get_sprite_by_id(sprite_id);
+        let position = shooting_plant.position.clone();
+
+        let plant_name = &Plant::from_name(&shooting_plant.name.clone());
+        let bullet_type = Plant::bullet_type(plant_name);
+
+        let mut bullet = Sprite::create_sprite(
+            bullet_type,
+            &ResourceKind::Plant,
+            &game.resources
+        ).remove(0);
+
+        bullet.update_position(Position::new(
+            position.top + 6.0,
+            position.left + 20.0
+        ));
+
+        BehaviorManager::toggle_sprite_behaviors(
+            &bullet,
+            &[BehaviorType::Animate, BehaviorType::Walk],
+            true,
+            now,
+        );
+
+        game.add_sprite(bullet);
     }
 
     pub fn allow_shovel_drag(game: &mut Game) {

--- a/src/scene/battle.rs
+++ b/src/scene/battle.rs
@@ -98,7 +98,7 @@ impl BattleScene {
         let seed_sprite = game.get_sprite_by_id(&selected_seed.0);
         seed_sprite.drawing_state.hover(false);
 
-        game.remove_sprites_by_id(vec![&selected_seed.1]);
+        game.remove_sprite_by_id(&selected_seed.1);
 
         Self::update_selected_cards_layout(game);
     }
@@ -170,7 +170,7 @@ impl BattleScene {
         sprite.order = 3; // TODO, Drag order based on behavior?
     }
 
-    pub fn create_bullet(game: &mut Game, sprite_id : &String) {
+    pub fn create_bullet(game: &mut Game, sprite_id: &String) {
         let now = game.game_time.time;
         let shooting_plant = game.get_sprite_by_id(sprite_id);
         let position = shooting_plant.position.clone();
@@ -178,16 +178,12 @@ impl BattleScene {
         let plant_name = &Plant::from_name(&shooting_plant.name.clone());
         let bullet_type = Plant::bullet_type(plant_name);
 
-        let mut bullet = Sprite::create_sprite(
-            bullet_type,
-            &ResourceKind::Plant,
-            &game.resources
-        ).remove(0);
+        let mut bullet =
+            Sprite::create_sprite(bullet_type, &ResourceKind::Plant, &game.resources).remove(0);
 
-        bullet.update_position(Position::new(
-            position.top + 6.0,
-            position.left + 20.0
-        ));
+        bullet.sprite_type = SpriteType::Bullet;
+
+        bullet.update_position(Position::new(position.top + 6.0, position.left + 20.0));
 
         BehaviorManager::toggle_sprite_behaviors(
             &bullet,

--- a/src/sprite/attack_state.rs
+++ b/src/sprite/attack_state.rs
@@ -16,4 +16,8 @@ impl AttackState {
     pub fn is_dead(&mut self) -> bool {
         self.life <= 0.0
     }
+
+    pub fn mute(&mut self) {
+        self.damage = 0.0;
+    }
 }

--- a/src/sprite/attack_state.rs
+++ b/src/sprite/attack_state.rs
@@ -1,0 +1,19 @@
+#[derive(Debug, Default)]
+pub struct AttackState {
+    pub life: f64,
+    pub damage: f64,
+}
+
+impl AttackState {
+    pub fn new(life: f64, damage: f64) -> Self {
+        AttackState { life, damage }
+    }
+
+    pub fn take_damage(&mut self, damage: f64) {
+        self.life -= damage;
+    }
+
+    pub fn is_dead(&mut self) -> bool {
+        self.life <= 0.0
+    }
+}

--- a/src/sprite/base.rs
+++ b/src/sprite/base.rs
@@ -3,8 +3,9 @@ use std::rc::Weak;
 
 use js_sys::Math;
 use web_sys::HtmlImageElement;
-use crate::board::{Board, BoardLocation};
 
+use crate::board::{Board, BoardLocation};
+use crate::log;
 use crate::model::{
     BehaviorData, Dimensions, Position, SpriteCell, SpriteData, SpriteType, TextOverlayData,
 };
@@ -27,6 +28,7 @@ pub struct Sprite {
     pub drawing_state: DrawingState,
     pub text_overlay: Option<TextOverlay>,
     pub sprite_type: SpriteType,
+    pub visible: bool,
 }
 
 impl Sprite {
@@ -64,6 +66,7 @@ impl Sprite {
             behaviors: sprite_behaviors,
             text_overlay: None,
             sprite_type: SpriteType::from_kind(&kind),
+            visible: true,
         };
 
         sprite.text_overlay = match text_overlay_data {
@@ -178,6 +181,10 @@ impl Sprite {
 
             if let Some(position) = mutation.position {
                 self.update_position(position);
+            }
+
+            if let Some(visible) = mutation.visible {
+                self.visible = visible;
             }
         });
     }

--- a/src/sprite/behavior/base.rs
+++ b/src/sprite/behavior/base.rs
@@ -22,9 +22,9 @@ pub trait BehaviorState {
 pub trait Behavior: BehaviorState {
     fn name(&self) -> BehaviorType;
 
-    fn on_stop(&mut self) {}
+    fn on_stop(&mut self, _now: f64) {}
 
-    fn on_start(&mut self) {}
+    fn on_start(&mut self, _now: f64) {}
 
     fn get_interaction(&self) -> Option<GameInteraction> {
         return None;
@@ -37,11 +37,11 @@ pub trait Behavior: BehaviorState {
     fn toggle(&mut self, run: bool, now: f64) {
         match run {
             true => {
-                self.on_start();
+                self.on_start(now);
                 self.start(now);
             }
             false => {
-                self.on_stop();
+                self.on_stop(now);
                 self.stop(now);
             }
         }

--- a/src/sprite/behavior/collision.rs
+++ b/src/sprite/behavior/collision.rs
@@ -3,11 +3,11 @@ use web_sys::CanvasRenderingContext2d;
 
 use super::base::Behavior;
 use crate::log;
-use crate::model::{BehaviorType, Callback, CollisionMargin, GameInteraction, Position};
-use crate::painter::Painter;
+use crate::model::{BehaviorType, CollisionMargin, Position};
 use crate::sprite::{Sprite, SpriteMutation};
+use crate::timers::Timer;
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum CollisionState {
     None,
     Attacking,
@@ -26,6 +26,10 @@ pub struct Collision {
     pub name: BehaviorType,
     pub margin: CollisionMargin,
     pub state: CollisionState,
+    pub last_collided: f64,
+
+    internal_timer: Timer,
+    delayed_mutation: Option<SpriteMutation>,
 }
 
 impl Collision {
@@ -34,8 +38,17 @@ impl Collision {
             margin,
             name: BehaviorType::Collision,
             state: CollisionState::None,
+            delayed_mutation: None,
+            internal_timer: Timer::new(10000.0),
             ..Default::default()
         }
+    }
+
+    fn set_delayed_mutation(&mut self, delay: f64, delayed_mutation: SpriteMutation) {
+        self.internal_timer.set_elapsed(delay);
+        self.internal_timer.start();
+
+        self.delayed_mutation = Some(delayed_mutation);
     }
 }
 
@@ -44,36 +57,52 @@ impl Behavior for Collision {
         BehaviorType::Collision
     }
 
+    /// Collision state is managed by the BattleManager,
+    /// this behavior just react into it's calculation instead of calculating its own.
     fn execute(
         &mut self,
         sprite: &Sprite,
-        now: f64,
+        _now: f64,
         _last_frame: f64,
-        mouse: &Position,
-        context: &CanvasRenderingContext2d,
+        _mouse: &Position,
+        _context: &CanvasRenderingContext2d,
     ) -> Option<SpriteMutation> {
         let mut mutation: Option<SpriteMutation> = None;
-        // Collision state is managed by the BattleManager, this behavior just react into it's calculation instead of calculating its own.
-        // TODO - Handle by CollisionType ?
-        // This should handle the `collided` flag respecting the type
+        let window_time = self.internal_timer.get_current_time(); // TODO Refactor start timer to work with `now`.
+
+        if self.delayed_mutation.is_some() && self.internal_timer.expired(window_time) {
+            let mutation = self.delayed_mutation.clone();
+            self.delayed_mutation = None;
+
+            return mutation;
+        }
 
         match self.state {
             CollisionState::None => {}
             CollisionState::Attacking => {
-                log!("CollisionAttack by {} ", sprite.id);
-                mutation = Some(SpriteMutation::new().hide());
+                if !self.delayed_mutation.is_some() {
+                    // TODO - Extract into a specific collision handle
+                    self.set_delayed_mutation(50.0, SpriteMutation::new().hide(true));
+                }
+
+                mutation = Some(SpriteMutation::new().swap(0).mute());
             }
             CollisionState::TakingDamage(damage) => {
-                log!(
-                    "Taking damage by {}  of / {}",
-                    sprite.attack_state.life,
-                    damage
-                );
-                mutation = Some(SpriteMutation::new().damage(damage))
+                if damage > 0.0 {
+                    log!(
+                        "Taking damage by {}  of / {}",
+                        sprite.attack_state.life,
+                        damage
+                    );
+
+                    if !self.delayed_mutation.is_some() {
+                        self.set_delayed_mutation(50.0, SpriteMutation::new().alpha(1.0));
+                    }
+
+                    mutation = Some(SpriteMutation::new().damage(damage).alpha(0.5))
+                }
             }
         }
-
-        self.state = CollisionState::None;
 
         mutation
     }

--- a/src/sprite/behavior/collision.rs
+++ b/src/sprite/behavior/collision.rs
@@ -1,0 +1,46 @@
+use derives::{derive_behavior_fields, BaseBehavior};
+use web_sys::CanvasRenderingContext2d;
+
+use super::base::Behavior;
+use crate::log;
+use crate::model::{BehaviorType, Callback, CollisionMargin, GameInteraction, Position};
+use crate::painter::Painter;
+use crate::sprite::{Sprite, SpriteMutation};
+
+#[derive_behavior_fields("")]
+#[derive(BaseBehavior, Default)]
+pub struct Collision {
+    pub name: BehaviorType,
+    pub margin: CollisionMargin,
+}
+
+impl Collision {
+    pub fn new(margin: CollisionMargin) -> Collision {
+        log!("Creating Collision behavior withs {:?}", margin);
+        Collision {
+            margin,
+            name: BehaviorType::Collision,
+            ..Default::default()
+        }
+    }
+}
+
+impl Behavior for Collision {
+    fn name(&self) -> BehaviorType {
+        BehaviorType::Collision
+    }
+
+    fn execute(
+        &mut self,
+        sprite: &Sprite,
+        now: f64,
+        _last_frame: f64,
+        mouse: &Position,
+        context: &CanvasRenderingContext2d,
+    ) -> Option<SpriteMutation> {
+        // TODO - Handle by CollisionType ?
+        // This should handle the `collided` flag respecting the type
+
+        None
+    }
+}

--- a/src/sprite/behavior/collision.rs
+++ b/src/sprite/behavior/collision.rs
@@ -7,19 +7,33 @@ use crate::model::{BehaviorType, Callback, CollisionMargin, GameInteraction, Pos
 use crate::painter::Painter;
 use crate::sprite::{Sprite, SpriteMutation};
 
+#[derive(Debug)]
+pub enum CollisionState {
+    None,
+    Attacking,
+    TakingDamage(f64),
+}
+
+impl Default for CollisionState {
+    fn default() -> Self {
+        CollisionState::None
+    }
+}
+
 #[derive_behavior_fields("")]
 #[derive(BaseBehavior, Default)]
 pub struct Collision {
     pub name: BehaviorType,
     pub margin: CollisionMargin,
+    pub state: CollisionState,
 }
 
 impl Collision {
     pub fn new(margin: CollisionMargin) -> Collision {
-        log!("Creating Collision behavior withs {:?}", margin);
         Collision {
             margin,
             name: BehaviorType::Collision,
+            state: CollisionState::None,
             ..Default::default()
         }
     }
@@ -38,9 +52,29 @@ impl Behavior for Collision {
         mouse: &Position,
         context: &CanvasRenderingContext2d,
     ) -> Option<SpriteMutation> {
+        let mut mutation: Option<SpriteMutation> = None;
+        // Collision state is managed by the BattleManager, this behavior just react into it's calculation instead of calculating its own.
         // TODO - Handle by CollisionType ?
         // This should handle the `collided` flag respecting the type
 
-        None
+        match self.state {
+            CollisionState::None => {}
+            CollisionState::Attacking => {
+                log!("CollisionAttack by {} ", sprite.id);
+                mutation = Some(SpriteMutation::new().hide());
+            }
+            CollisionState::TakingDamage(damage) => {
+                log!(
+                    "Taking damage by {}  of / {}",
+                    sprite.attack_state.life,
+                    damage
+                );
+                mutation = Some(SpriteMutation::new().damage(damage))
+            }
+        }
+
+        self.state = CollisionState::None;
+
+        mutation
     }
 }

--- a/src/sprite/behavior/drag.rs
+++ b/src/sprite/behavior/drag.rs
@@ -49,7 +49,7 @@ impl Behavior for Drag {
         BehaviorType::Drag
     }
 
-    fn on_stop(&mut self) {
+    fn on_stop(&mut self, _now: f64) {
         self.dragging = false;
         self.anchor = None;
         self.interaction_active = true;

--- a/src/sprite/behavior/interval.rs
+++ b/src/sprite/behavior/interval.rs
@@ -1,0 +1,73 @@
+use derives::{derive_behavior_fields, BaseBehavior};
+use web_sys::CanvasRenderingContext2d;
+
+use super::base::Behavior;
+use crate::model::{BehaviorType, Callback, GameInteraction, Position};
+use crate::sprite::{Sprite, SpriteMutation};
+use crate::timers::Timer;
+
+#[derive_behavior_fields("")]
+#[derive(BaseBehavior, Default)]
+pub struct Interval {
+    pub name: BehaviorType,
+    pub callback: Option<Callback>,
+    pub interval: f64,
+    timer: Timer
+}
+
+impl Interval {
+    pub fn new(interval: f64, callback: Option<Callback>) -> Interval {
+        Interval {
+            callback,
+            interval,
+            timer: Timer::new(interval),
+            name: BehaviorType::Click,
+            ..Default::default()
+        }
+    }
+}
+
+impl Behavior for Interval {
+    fn name(&self) -> BehaviorType {
+        BehaviorType::Interval
+    }
+
+    fn on_stop(&mut self, now: f64) {
+        self.timer.reset(Some(now))
+    }
+
+    fn on_start(&mut self, _now: f64) {
+        self.timer.start();
+    }
+
+    fn get_interaction(&self) -> Option<GameInteraction> {
+        if self.interaction_active {
+            return Some(GameInteraction::SpriteClick(
+                self.callback.unwrap(),
+                self.sprite_id.clone(),
+            ));
+        }
+
+        None
+    }
+
+    fn execute(
+        &mut self,
+        _sprite: &Sprite,
+        now: f64,
+        _last_frame: f64,
+        _mouse: &Position,
+        _context: &CanvasRenderingContext2d,
+    ) -> Option<SpriteMutation> {
+        if self.timer.expired(now) {
+            match self.callback {
+                None => {}
+                Some(_) => self.interaction_active = true
+            }
+
+            self.timer.reset(Some(now));
+        }
+
+        None
+    }
+}

--- a/src/sprite/behavior/interval.rs
+++ b/src/sprite/behavior/interval.rs
@@ -12,7 +12,7 @@ pub struct Interval {
     pub name: BehaviorType,
     pub callback: Option<Callback>,
     pub interval: f64,
-    timer: Timer
+    timer: Timer,
 }
 
 impl Interval {
@@ -62,7 +62,7 @@ impl Behavior for Interval {
         if self.timer.expired(now) {
             match self.callback {
                 None => {}
-                Some(_) => self.interaction_active = true
+                Some(_) => self.interaction_active = true,
             }
 
             self.timer.reset(Some(now));

--- a/src/sprite/behavior/mod.rs
+++ b/src/sprite/behavior/mod.rs
@@ -1,6 +1,7 @@
 pub use animate::Animate;
 pub use base::Behavior;
 pub use click::Click;
+pub use collision::{Collision, CollisionState};
 pub use hover::Hover;
 pub use interval::Interval;
 pub use scroll::Scroll;
@@ -8,7 +9,6 @@ pub use walk::Walk;
 use web_sys::CanvasRenderingContext2d;
 
 use crate::model::{BehaviorData, BehaviorType, GameInteraction, Position};
-use crate::sprite::behavior::collision::Collision;
 use crate::sprite::behavior::drag::Drag;
 use crate::sprite::{Sprite, SpriteMutation};
 use crate::timers::GameTime;
@@ -100,9 +100,10 @@ impl BehaviorManager {
         sprite: &mut Sprite,
         behavior: BehaviorType,
     ) -> &mut Box<dyn Behavior> {
+        let sprite_id = sprite.id.clone();
         Self::find_sprite_behavior(sprite, behavior).expect(&format!(
-            "[BehaviorManager] Cannot find Sprite behavior: {:?}",
-            behavior
+            "[BehaviorManager] Cannot GET Sprite behavior: {:?} / {}",
+            behavior, sprite_id
         ))
     }
 

--- a/src/sprite/behavior/mod.rs
+++ b/src/sprite/behavior/mod.rs
@@ -8,7 +8,7 @@ pub use scroll::Scroll;
 pub use walk::Walk;
 use web_sys::CanvasRenderingContext2d;
 
-use crate::model::{BehaviorData, BehaviorType, GameInteraction, Position};
+use crate::model::{BehaviorData, BehaviorType, CollisionMargin, GameInteraction, Position};
 use crate::sprite::behavior::drag::Drag;
 use crate::sprite::{Sprite, SpriteMutation};
 use crate::timers::GameTime;
@@ -46,7 +46,9 @@ impl BehaviorManager {
             BehaviorType::Walk => Box::new(Walk::new(data.distance, data.velocity.unwrap().clone())),
             BehaviorType::Drag => Box::new(Drag::new(data.callback.unwrap())),
             BehaviorType::Interval => Box::new(Interval::new(data.interval.unwrap(), data.callback)),
-            BehaviorType::Collision => Box::new(Collision::new(data.collision_margin.unwrap())),
+            BehaviorType::Collision => Box::new(Collision::new(
+                data.collision_margin.unwrap_or(CollisionMargin::default()),
+            )),
         };
 
         behavior.set_sprite_id(sprite_id);

--- a/src/sprite/behavior/mod.rs
+++ b/src/sprite/behavior/mod.rs
@@ -8,6 +8,7 @@ pub use walk::Walk;
 use web_sys::CanvasRenderingContext2d;
 
 use crate::model::{BehaviorData, BehaviorType, GameInteraction, Position};
+use crate::sprite::behavior::collision::Collision;
 use crate::sprite::behavior::drag::Drag;
 use crate::sprite::{Sprite, SpriteMutation};
 use crate::timers::GameTime;
@@ -15,6 +16,7 @@ use crate::timers::GameTime;
 mod animate;
 mod base;
 mod click;
+mod collision;
 mod drag;
 mod hover;
 mod interval;
@@ -44,6 +46,7 @@ impl BehaviorManager {
             BehaviorType::Walk => Box::new(Walk::new(data.distance, data.velocity.unwrap().clone())),
             BehaviorType::Drag => Box::new(Drag::new(data.callback.unwrap())),
             BehaviorType::Interval => Box::new(Interval::new(data.interval.unwrap(), data.callback)),
+            BehaviorType::Collision => Box::new(Collision::new(data.collision_margin.unwrap())),
         };
 
         behavior.set_sprite_id(sprite_id);
@@ -97,17 +100,21 @@ impl BehaviorManager {
         sprite: &mut Sprite,
         behavior: BehaviorType,
     ) -> &mut Box<dyn Behavior> {
-        let behavior = sprite
+        Self::find_sprite_behavior(sprite, behavior).expect(&format!(
+            "[BehaviorManager] Cannot find Sprite behavior: {:?}",
+            behavior
+        ))
+    }
+
+    pub fn find_sprite_behavior(
+        sprite: &mut Sprite,
+        behavior: BehaviorType,
+    ) -> Option<&mut Box<dyn Behavior>> {
+        sprite
             .behaviors
             .get_mut()
             .iter_mut()
             .find(|sprite_behavior| behavior == sprite_behavior.name())
-            .expect(&format!(
-                "[BehaviorManager] Cannot find Sprite behavior: {:?}",
-                behavior
-            ));
-
-        behavior
     }
 
     pub fn collect_interactions(sprite: &Sprite) -> Vec<GameInteraction> {

--- a/src/sprite/behavior/mod.rs
+++ b/src/sprite/behavior/mod.rs
@@ -2,10 +2,9 @@ pub use animate::Animate;
 pub use base::Behavior;
 pub use click::Click;
 pub use hover::Hover;
+pub use interval::Interval;
 pub use scroll::Scroll;
 pub use walk::Walk;
-pub use interval::Interval;
-
 use web_sys::CanvasRenderingContext2d;
 
 use crate::model::{BehaviorData, BehaviorType, GameInteraction, Position};
@@ -18,9 +17,9 @@ mod base;
 mod click;
 mod drag;
 mod hover;
+mod interval;
 mod scroll;
 mod walk;
-mod interval;
 
 pub struct BehaviorManager;
 
@@ -44,10 +43,7 @@ impl BehaviorManager {
             )),
             BehaviorType::Walk => Box::new(Walk::new(data.distance, data.velocity.unwrap().clone())),
             BehaviorType::Drag => Box::new(Drag::new(data.callback.unwrap())),
-            BehaviorType::Interval => Box::new(Interval::new(
-                data.interval.unwrap(),
-                data.callback
-            ))
+            BehaviorType::Interval => Box::new(Interval::new(data.interval.unwrap(), data.callback)),
         };
 
         behavior.set_sprite_id(sprite_id);

--- a/src/sprite/behavior/mod.rs
+++ b/src/sprite/behavior/mod.rs
@@ -4,6 +4,8 @@ pub use click::Click;
 pub use hover::Hover;
 pub use scroll::Scroll;
 pub use walk::Walk;
+pub use interval::Interval;
+
 use web_sys::CanvasRenderingContext2d;
 
 use crate::model::{BehaviorData, BehaviorType, GameInteraction, Position};
@@ -18,6 +20,7 @@ mod drag;
 mod hover;
 mod scroll;
 mod walk;
+mod interval;
 
 pub struct BehaviorManager;
 
@@ -41,6 +44,10 @@ impl BehaviorManager {
             )),
             BehaviorType::Walk => Box::new(Walk::new(data.distance, data.velocity.unwrap().clone())),
             BehaviorType::Drag => Box::new(Drag::new(data.callback.unwrap())),
+            BehaviorType::Interval => Box::new(Interval::new(
+                data.interval.unwrap(),
+                data.callback
+            ))
         };
 
         behavior.set_sprite_id(sprite_id);
@@ -72,13 +79,22 @@ impl BehaviorManager {
         now: f64,
     ) {
         sprites.iter().for_each(|sprite| {
-            sprite
-                .mutable_behaviors()
-                .iter_mut()
-                .filter(|behavior| behavior.is_running() != should_run)
-                .filter(|behavior| behavior_types.contains(&behavior.name()))
-                .for_each(|behavior| behavior.toggle(should_run, now));
+            Self::toggle_sprite_behaviors(sprite, behavior_types, should_run, now)
         });
+    }
+
+    pub fn toggle_sprite_behaviors(
+        sprite: &Sprite,
+        behavior_types: &[BehaviorType],
+        should_run: bool,
+        now: f64,
+    ) {
+        sprite
+            .mutable_behaviors()
+            .iter_mut()
+            .filter(|behavior| behavior.is_running() != should_run)
+            .filter(|behavior| behavior_types.contains(&behavior.name()))
+            .for_each(|behavior| behavior.toggle(should_run, now));
     }
 
     pub fn get_sprite_behavior(

--- a/src/sprite/behavior/walk.rs
+++ b/src/sprite/behavior/walk.rs
@@ -67,7 +67,7 @@ impl Behavior for Walk {
 
         if Board::is_out_of_board(sprite, &new_position) {
             self.stop(now);
-            return Some(SpriteMutation::new().hide());
+            return Some(SpriteMutation::new().hide(true));
         }
 
         self.walked_distance += self.position_distance(&offset);

--- a/src/sprite/behavior/walk.rs
+++ b/src/sprite/behavior/walk.rs
@@ -2,6 +2,7 @@ use derives::{derive_behavior_fields, BaseBehavior};
 use web_sys::CanvasRenderingContext2d;
 
 use super::base::Behavior;
+use crate::board::Board;
 use crate::model::{BehaviorType, Position, Velocity};
 use crate::sprite::{Sprite, SpriteMutation};
 
@@ -59,13 +60,18 @@ impl Behavior for Walk {
         let animation_rate = self.animation_rate(now, last_frame);
         let offset = self.calculate_offset(animation_rate);
 
-        // TODO - Calculate if movement is allowed (Not out of board)
+        let new_position = Position::new(
+            sprite.position.top + offset.top,
+            sprite.position.left + offset.left,
+        );
+
+        if Board::is_out_of_board(sprite, &new_position) {
+            self.stop(now);
+            return Some(SpriteMutation::new().hide());
+        }
 
         self.walked_distance += self.position_distance(&offset);
 
-        Some(SpriteMutation::new().position(Position::new(
-            sprite.position.top + offset.top,
-            sprite.position.left + offset.left,
-        )))
+        Some(SpriteMutation::new().position(new_position))
     }
 }

--- a/src/sprite/drawing_state.rs
+++ b/src/sprite/drawing_state.rs
@@ -4,32 +4,55 @@ use crate::sprite::Sprite;
 #[derive(Debug, Default)]
 pub struct DrawingState {
     pub cells: Vec<SpriteCell>,
+    pub swap_cells: Vec<Vec<SpriteCell>>,
+    pub swap_index: Option<usize>,
     pub active_cell: usize,
     pub scale: f64,
     pub offset: Position,
+    pub alpha: f64,
 }
 
 impl DrawingState {
-    pub fn new(cells: Vec<SpriteCell>, scale: f64, offset: Position) -> Self {
+    pub fn new(
+        cells: Vec<SpriteCell>,
+        swap_cells: Vec<Vec<SpriteCell>>,
+        scale: f64,
+        offset: Position,
+    ) -> Self {
         Self {
             scale,
             cells,
+            swap_cells,
             offset,
+            alpha: 1.0,
             ..DrawingState::default()
         }
     }
 
     pub fn get_active_cell(sprite: &Sprite) -> &SpriteCell {
         let drawing_state = &sprite.drawing_state;
-        let cell = drawing_state
-            .cells
-            .get(drawing_state.active_cell)
-            .expect(&format!(
-                "[Sprite] Cannot get drawing state cell of {} / {}",
-                sprite.name, drawing_state.active_cell
-            ));
+
+        let cells = match drawing_state.swap_index {
+            None => &drawing_state.cells,
+            Some(index) => &drawing_state.swap_cells[index],
+        };
+
+        let cell = cells.get(drawing_state.active_cell).expect(&format!(
+            "[Sprite] Cannot get drawing state cell of {} / {} / {:?}",
+            sprite.name, drawing_state.active_cell, drawing_state.swap_index
+        ));
 
         return cell;
+    }
+
+    pub fn swap(&mut self, swap_index: usize) {
+        self.active_cell = 0;
+        self.swap_index = Some(swap_index);
+    }
+
+    pub fn reset_swap(&mut self) {
+        self.active_cell = 0;
+        self.swap_index = None;
     }
 
     pub fn hover(&mut self, hover: bool) {

--- a/src/sprite/mod.rs
+++ b/src/sprite/mod.rs
@@ -1,13 +1,14 @@
+mod attack_state;
 mod base;
 mod behavior;
 mod drawing_state;
-mod model;
+mod mutations;
 mod outline;
 mod text_overlay;
 
 pub use base::Sprite;
-pub use behavior::{BehaviorManager, Click, Hover, Scroll};
+pub use behavior::{BehaviorManager, Click, Collision, CollisionState, Hover, Scroll};
 pub use drawing_state::DrawingState;
-pub use model::SpriteMutation;
+pub use mutations::SpriteMutation;
 pub use outline::Outline;
 pub use text_overlay::TextOverlay;

--- a/src/sprite/model.rs
+++ b/src/sprite/model.rs
@@ -5,6 +5,7 @@ pub struct SpriteMutation {
     pub offset: Option<Position>,
     pub hovered: Option<bool>,
     pub cycle_cells: Option<bool>,
+    pub visible: Option<bool>,
 }
 
 impl SpriteMutation {
@@ -14,6 +15,7 @@ impl SpriteMutation {
             offset: None,
             hovered: None,
             cycle_cells: None,
+            visible: None,
         }
     }
 
@@ -37,6 +39,12 @@ impl SpriteMutation {
 
     pub fn cycle(mut self) -> Self {
         self.cycle_cells = Some(true);
+
+        self
+    }
+
+    pub fn hide(mut self) -> Self {
+        self.visible = Some(false);
 
         self
     }

--- a/src/sprite/mutations.rs
+++ b/src/sprite/mutations.rs
@@ -6,6 +6,7 @@ pub struct SpriteMutation {
     pub hovered: Option<bool>,
     pub cycle_cells: Option<bool>,
     pub visible: Option<bool>,
+    pub damage: Option<f64>,
 }
 
 impl SpriteMutation {
@@ -16,6 +17,7 @@ impl SpriteMutation {
             hovered: None,
             cycle_cells: None,
             visible: None,
+            damage: None,
         }
     }
 
@@ -45,6 +47,12 @@ impl SpriteMutation {
 
     pub fn hide(mut self) -> Self {
         self.visible = Some(false);
+
+        self
+    }
+
+    pub fn damage(mut self, damage: f64) -> Self {
+        self.damage = Some(damage);
 
         self
     }

--- a/src/sprite/mutations.rs
+++ b/src/sprite/mutations.rs
@@ -1,12 +1,16 @@
 use crate::model::Position;
 
+#[derive(Debug, Clone)]
 pub struct SpriteMutation {
     pub position: Option<Position>,
     pub offset: Option<Position>,
     pub hovered: Option<bool>,
+    pub swap: Option<i32>,
     pub cycle_cells: Option<bool>,
     pub visible: Option<bool>,
+    pub mute: Option<bool>,
     pub damage: Option<f64>,
+    pub alpha: Option<f64>,
 }
 
 impl SpriteMutation {
@@ -18,6 +22,9 @@ impl SpriteMutation {
             cycle_cells: None,
             visible: None,
             damage: None,
+            swap: None,
+            mute: None,
+            alpha: None,
         }
     }
 
@@ -45,14 +52,32 @@ impl SpriteMutation {
         self
     }
 
-    pub fn hide(mut self) -> Self {
-        self.visible = Some(false);
+    pub fn hide(mut self, hide: bool) -> Self {
+        self.visible = Some(!hide);
 
         self
     }
 
     pub fn damage(mut self, damage: f64) -> Self {
         self.damage = Some(damage);
+
+        self
+    }
+
+    pub fn swap(mut self, swap_index: i32) -> Self {
+        self.swap = Some(swap_index);
+
+        self
+    }
+
+    pub fn mute(mut self) -> Self {
+        self.mute = Some(true);
+
+        self
+    }
+
+    pub fn alpha(mut self, alpha: f64) -> Self {
+        self.alpha = Some(alpha);
 
         self
     }

--- a/src/sprite/outline/mod.rs
+++ b/src/sprite/outline/mod.rs
@@ -57,7 +57,14 @@ impl Outline {
         let painter = Painter::get_measurements_painter(size);
 
         let starting_point = Position::new(0.0, 0.0);
-        painter.draw_image(&image_ref, &starting_point, &starting_point, cell, scale);
+        painter.draw_image(
+            &image_ref,
+            &starting_point,
+            &starting_point,
+            cell,
+            scale,
+            1.0,
+        );
 
         let image_data = painter
             .context

--- a/src/timers/base_timer.rs
+++ b/src/timers/base_timer.rs
@@ -1,10 +1,9 @@
-use crate::log;
 use crate::web_utils::window_time;
 
 #[derive(Debug, Default)]
 pub struct Timer {
     elapsed: f64,
-    running: bool,
+    pub running: bool,
     start_time: f64,
 }
 
@@ -15,6 +14,10 @@ impl Timer {
             running: false,
             start_time: 0.0,
         }
+    }
+
+    pub fn set_elapsed(&mut self, elapsed: f64) {
+        self.elapsed = elapsed;
     }
 
     pub fn get_current_time(&self) -> f64 {
@@ -41,6 +44,10 @@ impl Timer {
     }
 
     pub fn expired(&self, now: f64) -> bool {
+        if !self.running {
+            return false;
+        }
+
         self.get_elapsed_time(now) >= self.elapsed
     }
 }

--- a/src/timers/base_timer.rs
+++ b/src/timers/base_timer.rs
@@ -1,3 +1,4 @@
+use crate::log;
 use crate::web_utils::window_time;
 
 #[derive(Debug, Default)]
@@ -37,5 +38,9 @@ impl Timer {
             true => now - self.start_time,
             false => self.elapsed,
         }
+    }
+
+    pub fn expired(&self, now: f64) -> bool {
+        self.get_elapsed_time(now) >= self.elapsed
     }
 }


### PR DESCRIPTION
**Main changes**
- Enable basic game shooting and fighting management which works with the following parts:
    - First, the `BattleManager` iterate game sprites, bulking per `BoardRow` and processing items collision, If found it will mark the Sprites participating in the battle with the respective `CollisionState`.
    - Later the `Collision` behavior will act respectively to it's current state controlled by the battle manager, and using mutations will apply changes upon any desired end.
- Support `swap_cells` mutation, Allow a given sprite to change it active cells with another vector of `SpriteCell`.
- Adding internal `GC` for clearing invisible sprites.
- `AttackState` was added to `Sprite` entity, marking it's attack state propeties.

**Scene**
- Plants now can shoot bullets.
- Zombies flash'es once hit, and disappear if dead.
- Bullets swap cells into explosion and disspear.

**Side effects**
- Aligning `data.json` assets to fit current behaviors.
- `Walk` bahvior now follows `out_of_board` and hides the Sprite in case it's out.


**Missing:**
- `Collision Behavior` should create a `CollisionHandler` which is a trait, representing each entity that can collide.
It should have an `on_attack` / `on_hit` API.
`on_hit` can return a `SpriteMutation` and a delay tupple.
- `Zombies` collision state
- `Plants` collision state
- `LawnCleaners` Collision handling.