### PR TITLE
Zombie death scene

### DIFF
--- a/assets/json/interface-cell.json
+++ b/assets/json/interface-cell.json
@@ -10,7 +10,7 @@
   "FlagMeterParts1": [{ "left": 291, "top": 1789, "width": 22, "height": 23 }],
   "FlagMeterParts2": [{ "left": 86, "top": 1881, "width": 20, "height": 18 }],
   "LawnCleaner": [{ "left": 1700, "top": 1520, "width": 70, "height": 57 }],
-  "PrepareGrowPlants": [
+  "BattleCallout": [
     { "left": 1618, "top": 1712, "width": 255, "height": 108 },
     { "left": 1623, "top": 1017, "width": 255, "height": 108 },
     { "left": 1623, "top": 909, "width": 255, "height": 108 }

--- a/assets/json/interface-data.json
+++ b/assets/json/interface-data.json
@@ -136,7 +136,7 @@
   "PrepareGrowPlants": {
     "constructor": "Sprite",
     "position": [{ "left": 322.5, "top": 246 }],
-    "behaviors": [{ "name": "Frequency", "duration": 1000, "delay": 1000 }]
+    "behaviors": [{ "name": "Animate", "rate": 1250, "callback": "StartBattle" }]
   },
   "SeedChooserBackground": {
     "constructor": "Sprite",

--- a/assets/json/interface-data.json
+++ b/assets/json/interface-data.json
@@ -133,7 +133,7 @@
     "order": 2,
     "hurt": 99999
   },
-  "PrepareGrowPlants": {
+  "BattleCallout": {
     "constructor": "Sprite",
     "position": [{ "left": 322.5, "top": 246 }],
     "behaviors": [{ "name": "Animate", "rate": 1250, "callback": "StartBattle" }]

--- a/assets/json/level-data.json
+++ b/assets/json/level-data.json
@@ -12,7 +12,13 @@
       "TallNut"
     ],
     "zombies": [
-      "Buckethead"
+      "Buckethead",
+      "Conehead",
+      "ScreenDoor",
+      "Conehead",
+      "Conehead",
+      "Zombie1",
+      "Flag"
     ]
   }
 }

--- a/assets/json/level-data.json
+++ b/assets/json/level-data.json
@@ -12,13 +12,7 @@
       "TallNut"
     ],
     "zombies": [
-      "Buckethead",
-      "Conehead",
-      "ScreenDoor",
-      "Conehead",
-      "Conehead",
-      "Zombie1",
-      "Flag"
+      "Buckethead"
     ]
   }
 }

--- a/assets/json/plant-data.json
+++ b/assets/json/plant-data.json
@@ -4,35 +4,37 @@
     "position": [{ "left": 0, "top": 0 }],
     "behaviors": [
       { "name": "Animate", "rate": 120, "max_cycles": 0 },
-      { "name": "Interval", "interval": 3000, "callback": "Shoot" }
+      { "name": "Interval", "interval": 3000, "callback": "Shoot" },
+      { "name": "Collision" }
     ]
   },
   "Torchwood": {
     "constructor": "PlantSprite",
     "position": [{ "left": 0, "top": 0 }],
-    "behaviors": [{ "name": "Animate", "rate": 120, "max_cycles": 0 }]
+    "behaviors": [{ "name": "Animate", "rate": 120, "max_cycles": 0 }, { "name": "Collision" }]
   },
   "WallNut": {
     "constructor": "PlantSprite",
     "position": [{ "left": 0, "top": 0 }],
-    "behaviors": [{ "name": "Animate", "rate": 120, "max_cycles": 0 }]
+    "behaviors": [{ "name": "Animate", "rate": 120, "max_cycles": 0 }, { "name": "Collision" }]
   },
   "TallNut": {
     "constructor": "PlantSprite",
     "position": [{ "left": 0, "top": 0 }],
-    "behaviors": [{ "name": "Animate", "rate": 120, "max_cycles": 0 }]
+    "behaviors": [{ "name": "Animate", "rate": 120, "max_cycles": 0 }, { "name": "Collision" }]
   },
   "PumpkinHead": {
     "constructor": "PlantSprite",
     "position": [{ "left": 0, "top": 0 }],
-    "behaviors": [{ "name": "Animate", "rate": 120, "max_cycles": 0 }]
+    "behaviors": [{ "name": "Animate", "rate": 120, "max_cycles": 0 }, { "name": "Collision" }]
   },
   "SunFlower": {
     "constructor": "PlantSprite",
     "position": [{ "left": 0, "top": 0 }],
     "behaviors": [
       { "name": "Animate", "rate": 120, "max_cycles": 0 },
-      { "name": "Interval", "interval": 7200, "callback": "GenerateSunFlowSun" }
+      { "name": "Interval", "interval": 7200, "callback": "GenerateSunFlowSun" },
+      { "name": "Collision" }
     ]
   },
   "SnowPea": {
@@ -40,7 +42,8 @@
     "position": [{ "left": 0, "top": 0 }],
     "behaviors": [
       { "name": "Animate", "rate": 120, "max_cycles": 0 },
-      { "name": "Interval", "interval": 3000, "callback": "Shoot" }
+      { "name": "Interval", "interval": 3000, "callback": "Shoot" },
+      { "name": "Collision" }
     ]
   },
   "SnowBullet": {

--- a/assets/json/plant-data.json
+++ b/assets/json/plant-data.json
@@ -51,6 +51,7 @@
     "position": [{ "left": 100, "top": 150 }],
     "swap_cells": ["PeaBulletHit"],
     "damage": 25.0,
+    "order": 10,
     "behaviors": [
       { "name": "Animate", "rate": 120, "max_cycles": 0 },
       { "name": "Walk", "velocity": { "x": 250, "y": 0 }},
@@ -61,6 +62,7 @@
     "constructor": "PlantSprite",
     "swap_cells": ["PeaBulletHit"],
     "damage": 25.0,
+    "order": 10,
     "position": [{ "left": 100, "top": 250 }],
     "behaviors": [
       { "name": "Animate", "rate": 120, "max_cycles": 0 },
@@ -71,6 +73,7 @@
   "FireBullet": {
     "constructor": "PlantSprite",
     "damage": 35.0,
+    "order": 10,
     "position": [{ "left": 100, "top": 450 }],
     "behaviors": [
       { "name": "Animate", "rate": 120, "max_cycles": 0 },
@@ -80,6 +83,7 @@
   },
   "ReverseFireBullet": {
     "damage": 35.0,
+    "order": 10,
     "constructor": "PlantSprite",
     "position": [{ "left": 100, "top": 550 }],
     "behaviors": [

--- a/assets/json/zombie-cell.json
+++ b/assets/json/zombie-cell.json
@@ -2139,16 +2139,16 @@
     { "left": 4963, "top": 0, "width": 79, "height": 113 }
   ],
   "ZombieDie": [
-    { "left": 695, "top": 918, "width": 165, "height": 85 },
-    { "left": 1335, "top": 2532, "width": 165, "height": 85 },
-    { "left": 1335, "top": 2617, "width": 165, "height": 85 },
-    { "left": 739, "top": 5272, "width": 165, "height": 85 },
-    { "left": 574, "top": 5272, "width": 165, "height": 85 },
-    { "left": 1335, "top": 2447, "width": 165, "height": 85 },
-    { "left": 1290, "top": 1596, "width": 165, "height": 85 },
-    { "left": 955, "top": 2320, "width": 165, "height": 85 },
-    { "left": 1147, "top": 3832, "width": 165, "height": 85 },
-    { "left": 1335, "top": 2702, "width": 165, "height": 85 }
+    { "left": 695, "top": 918, "width": 163, "height": 85 },
+    { "left": 1335, "top": 2532, "width": 163, "height": 85 },
+    { "left": 1335, "top": 2617, "width": 163, "height": 85 },
+    { "left": 739, "top": 5272, "width": 163, "height": 85 },
+    { "left": 574, "top": 5272, "width": 163, "height": 85 },
+    { "left": 1335, "top": 2447, "width": 163, "height": 85 },
+    { "left": 1290, "top": 1596, "width": 163, "height": 85 },
+    { "left": 955, "top": 2320, "width": 163, "height": 85 },
+    { "left": 1147, "top": 3832, "width": 163, "height": 85 },
+    { "left": 1335, "top": 2702, "width": 163, "height": 85 }
   ],
   "ZombieHead": [
     { "left": 1944, "top": 3256, "width": 140, "height": 185 },

--- a/assets/json/zombie-data.json
+++ b/assets/json/zombie-data.json
@@ -15,11 +15,11 @@
     "position": [{ "left": 0, "top": 0 }],
     "behaviors": [
       { "name": "Animate", "rate": 160, "max_cycles": 0 },
-      { "name": "Walk", "velocity": { "x": -20, "y": 0 } },
+      { "name": "Walk", "velocity": { "x": -9, "y": 0 } },
       { "name": "Collision", "collision_margin": { "left": 30, "top": 5, "right": 10, "bottom": 5 }}
     ],
     "life": 200,
-    "damage": 70.0
+    "damage": 15.0
   },
   "Flag": {
     "constructor": "Zombie",

--- a/assets/json/zombie-data.json
+++ b/assets/json/zombie-data.json
@@ -17,7 +17,7 @@
     "swap_cells": ["BucketheadWalk", "BucketheadAttack", "ZombieWalk1", "ZombieAttack", "ZombieDie"],
     "behaviors": [
       { "name": "Animate", "rate": 130, "max_cycles": 0 },
-      { "name": "Walk", "velocity": { "x": -9, "y": 0 } },
+      { "name": "Walk", "velocity": { "x": -15, "y": 0 } },
       { "name": "Collision", "collision_margin": { "left": 30, "top": 5, "right": 10, "bottom": 5 }}
     ],
     "life": 250,
@@ -63,15 +63,13 @@
     "constructor": "Zombie",
     "position": [{ "left": 0, "top": 0 }],
     "behaviors": [
-      { "name": "Animate", "rate": 100, "max_cycles": 0 },
+      { "name": "Animate", "rate": 100, "max_cycles": 1 },
       {
         "name": "Walk",
         "velocity": { "x": 20, "y": -45 },
         "distance": 45
-      },
-      { "name": "Collision" }
-    ],
-    "life": 0.0
+      }
+    ]
   },
   "ZombieDie": {
     "constructor": "Zombie",

--- a/assets/json/zombie-data.json
+++ b/assets/json/zombie-data.json
@@ -3,7 +3,7 @@
     "constructor": "Zombie",
     "position": [{ "left": 0, "top": 0 }],
     "behaviors": [
-      { "name": "Animate", "rate": 160, "max_cycles": 0 },
+      { "name": "Animate", "rate": 130, "max_cycles": 0 },
       { "name": "Walk", "velocity": { "x": -10, "y": 0 } },
       { "name": "Collision", "collision_margin": { "left": 30, "top": 5, "right": 10, "bottom": 5 }}
     ],
@@ -15,18 +15,18 @@
     "position": [{ "left": 0, "top": 0 }],
     "swap_cells": ["BucketheadWalk", "BucketheadAttack", "ZombieWalk1", "ZombieAttack", "ZombieDie"],
     "behaviors": [
-      { "name": "Animate", "rate": 160, "max_cycles": 0 },
+      { "name": "Animate", "rate": 130, "max_cycles": 0 },
       { "name": "Walk", "velocity": { "x": -9, "y": 0 } },
       { "name": "Collision", "collision_margin": { "left": 30, "top": 5, "right": 10, "bottom": 5 }}
     ],
-    "life": 200,
+    "life": 25,
     "damage": 15.0
   },
   "Flag": {
     "constructor": "Zombie",
     "position": [{ "left": 0, "top": 0 }],
     "behaviors": [
-      { "name": "Animate", "rate": 160, "max_cycles": 0 },
+      { "name": "Animate", "rate": 130, "max_cycles": 0 },
       { "name": "Walk", "velocity": { "x": -8, "y": 0 } },
       { "name": "Collision", "collision_margin": { "left": 40, "top": 5, "right": 10, "bottom": 5 }}
     ],
@@ -37,7 +37,7 @@
     "constructor": "Zombie",
     "position": [{ "left": 0, "top": 0 }],
     "behaviors": [
-      { "name": "Animate", "rate": 160, "max_cycles": 0 },
+      { "name": "Animate", "rate": 130, "max_cycles": 0 },
       { "name": "Walk", "velocity": { "x": -12, "y": 0 } },
       { "name": "Collision" }
     ],
@@ -48,7 +48,7 @@
     "constructor": "Zombie",
     "position": [{ "left": 0, "top": 0 }],
     "behaviors": [
-      { "name": "Animate", "rate": 160, "max_cycles": 0 },
+      { "name": "Animate", "rate": 130, "max_cycles": 0 },
       { "name": "Walk", "velocity": { "x": -5, "y": 0 } },
       { "name": "Collision" }
     ],
@@ -73,7 +73,7 @@
     "constructor": "Zombie",
     "position": [{ "left": 0, "top": 0 }],
     "behaviors": [
-      { "name": "Animate", "rate": 160, "max_cycles": 0 },
+      { "name": "Animate", "rate": 130, "max_cycles": 0 },
       { "name": "Collision" }
     ],
     "life": 0.0

--- a/assets/json/zombie-data.json
+++ b/assets/json/zombie-data.json
@@ -7,17 +7,19 @@
       { "name": "Walk", "velocity": { "x": -10, "y": 0 } },
       { "name": "Collision", "collision_margin": { "left": 30, "top": 5, "right": 10, "bottom": 5 }}
     ],
-    "life": 200
+    "life": 200,
+    "damage": 10.0
   },
   "Buckethead": {
     "constructor": "Zombie",
     "position": [{ "left": 0, "top": 0 }],
     "behaviors": [
       { "name": "Animate", "rate": 160, "max_cycles": 0 },
-      { "name": "Walk", "velocity": { "x": -9, "y": 0 } },
+      { "name": "Walk", "velocity": { "x": -20, "y": 0 } },
       { "name": "Collision", "collision_margin": { "left": 30, "top": 5, "right": 10, "bottom": 5 }}
     ],
-    "life": 200
+    "life": 200,
+    "damage": 70.0
   },
   "Flag": {
     "constructor": "Zombie",
@@ -26,7 +28,9 @@
       { "name": "Animate", "rate": 160, "max_cycles": 0 },
       { "name": "Walk", "velocity": { "x": -8, "y": 0 } },
       { "name": "Collision", "collision_margin": { "left": 40, "top": 5, "right": 10, "bottom": 5 }}
-    ]
+    ],
+    "life": 200,
+    "damage": 10.0
   },
   "ScreenDoor": {
     "constructor": "Zombie",
@@ -36,7 +40,8 @@
       { "name": "Walk", "velocity": { "x": -12, "y": 0 } },
       { "name": "Collision" }
     ],
-    "life": 200
+    "life": 200,
+    "damage": 10.0
   },
   "Zombie1": {
     "constructor": "Zombie",
@@ -45,7 +50,9 @@
       { "name": "Animate", "rate": 160, "max_cycles": 0 },
       { "name": "Walk", "velocity": { "x": -5, "y": 0 } },
       { "name": "Collision" }
-    ]
+    ],
+    "life": 200,
+    "damage": 10.0
   },
   "ZombieHead": {
     "constructor": "Zombie",

--- a/assets/json/zombie-data.json
+++ b/assets/json/zombie-data.json
@@ -2,13 +2,14 @@
   "Conehead": {
     "constructor": "Zombie",
     "position": [{ "left": 0, "top": 0 }],
+    "swap_cells": ["ConeheadWalk", "ConeheadAttack", "ZombieWalk1", "ZombieAttack", "ZombieDie"],
     "behaviors": [
       { "name": "Animate", "rate": 130, "max_cycles": 0 },
       { "name": "Walk", "velocity": { "x": -10, "y": 0 } },
       { "name": "Collision", "collision_margin": { "left": 30, "top": 5, "right": 10, "bottom": 5 }}
     ],
     "life": 200,
-    "damage": 10.0
+    "damage": 15.0
   },
   "Buckethead": {
     "constructor": "Zombie",
@@ -19,40 +20,43 @@
       { "name": "Walk", "velocity": { "x": -9, "y": 0 } },
       { "name": "Collision", "collision_margin": { "left": 30, "top": 5, "right": 10, "bottom": 5 }}
     ],
-    "life": 125,
+    "life": 250,
     "damage": 15.0
   },
   "Flag": {
     "constructor": "Zombie",
     "position": [{ "left": 0, "top": 0 }],
+    "swap_cells": ["FlagWalk", "FlagAttack", "FlagWalk", "FlagAttack", "ZombieDie"],
     "behaviors": [
       { "name": "Animate", "rate": 130, "max_cycles": 0 },
       { "name": "Walk", "velocity": { "x": -8, "y": 0 } },
       { "name": "Collision", "collision_margin": { "left": 40, "top": 5, "right": 10, "bottom": 5 }}
     ],
-    "life": 200,
+    "life": 150,
     "damage": 10.0
   },
   "ScreenDoor": {
     "constructor": "Zombie",
     "position": [{ "left": 0, "top": 0 }],
+    "swap_cells": ["ScreenDoorWalk", "ScreenDoorAttack", "ZombieWalk1", "ZombieAttack", "ZombieDie"],
     "behaviors": [
       { "name": "Animate", "rate": 130, "max_cycles": 0 },
       { "name": "Walk", "velocity": { "x": -12, "y": 0 } },
       { "name": "Collision" }
     ],
-    "life": 200,
-    "damage": 10.0
+    "life": 225,
+    "damage": 12.5
   },
   "Zombie1": {
     "constructor": "Zombie",
     "position": [{ "left": 0, "top": 0 }],
+    "swap_cells": ["ZombieWalk1", "ZombieAttack", "ZombieWalk1", "ZombieAttack", "ZombieDie"],
     "behaviors": [
       { "name": "Animate", "rate": 130, "max_cycles": 0 },
       { "name": "Walk", "velocity": { "x": -5, "y": 0 } },
       { "name": "Collision" }
     ],
-    "life": 200,
+    "life": 100,
     "damage": 10.0
   },
   "ZombieHead": {
@@ -62,7 +66,7 @@
       { "name": "Animate", "rate": 100, "max_cycles": 0 },
       {
         "name": "Walk",
-        "velocit": { "x": 20, "y": -45 },
+        "velocity": { "x": 20, "y": -45 },
         "distance": 45
       },
       { "name": "Collision" }

--- a/assets/json/zombie-data.json
+++ b/assets/json/zombie-data.json
@@ -13,6 +13,7 @@
   "Buckethead": {
     "constructor": "Zombie",
     "position": [{ "left": 0, "top": 0 }],
+    "swap_cells": ["BucketheadWalk", "BucketheadAttack"],
     "behaviors": [
       { "name": "Animate", "rate": 160, "max_cycles": 0 },
       { "name": "Walk", "velocity": { "x": -9, "y": 0 } },

--- a/assets/json/zombie-data.json
+++ b/assets/json/zombie-data.json
@@ -19,7 +19,7 @@
       { "name": "Walk", "velocity": { "x": -9, "y": 0 } },
       { "name": "Collision", "collision_margin": { "left": 30, "top": 5, "right": 10, "bottom": 5 }}
     ],
-    "life": 25,
+    "life": 125,
     "damage": 15.0
   },
   "Flag": {

--- a/assets/json/zombie-data.json
+++ b/assets/json/zombie-data.json
@@ -13,7 +13,7 @@
   "Buckethead": {
     "constructor": "Zombie",
     "position": [{ "left": 0, "top": 0 }],
-    "swap_cells": ["BucketheadWalk", "BucketheadAttack"],
+    "swap_cells": ["BucketheadWalk", "BucketheadAttack", "ZombieWalk1", "ZombieAttack", "ZombieDie"],
     "behaviors": [
       { "name": "Animate", "rate": 160, "max_cycles": 0 },
       { "name": "Walk", "velocity": { "x": -9, "y": 0 } },

--- a/src/battle_manage.rs
+++ b/src/battle_manage.rs
@@ -1,10 +1,9 @@
 use itertools::Itertools;
 
 use crate::game::Game;
-use crate::log;
 use crate::model::{BehaviorType, CollisionMargin, SpriteType};
 use crate::sprite::{
-    BehaviorManager, Collision, CollisionState, DrawingState, Sprite, SpriteMutation,
+    BehaviorManager, Collision, CollisionState, DrawingState, Sprite,
 };
 
 struct CollisionMutation {

--- a/src/battle_manage.rs
+++ b/src/battle_manage.rs
@@ -2,9 +2,7 @@ use itertools::Itertools;
 
 use crate::game::Game;
 use crate::model::{BehaviorType, CollisionMargin, SpriteType};
-use crate::sprite::{
-    BehaviorManager, Collision, CollisionState, DrawingState, Sprite,
-};
+use crate::sprite::{BehaviorManager, Collision, CollisionState, DrawingState, Sprite};
 
 struct CollisionMutation {
     attacking_id: String,

--- a/src/battle_manage.rs
+++ b/src/battle_manage.rs
@@ -54,12 +54,10 @@ impl BattleManager {
                 if mutations.len() > 0 {
                     mutations.iter().for_each(|mutation| {
                         if mutation.attacking_id == sprite_id {
-                            log!("Processing attack mutation1 {}", mutation.attacking_id);
                             collision.state = CollisionState::Attacking;
                         }
 
                         if mutation.target_id == sprite_id {
-                            log!("Processing damage{}", mutation.target_id);
                             collision.state = CollisionState::TakingDamage(mutation.damage);
                         }
                     })
@@ -84,10 +82,6 @@ impl BattleManager {
 
                 group.into_iter().for_each(|sprite| {
                     // For each given sprite within the group, finding respective collision candidates
-                    if !sprite.attack_state.attack_enabled {
-                        return;
-                    }
-
                     let candidates = others
                         .iter()
                         .filter(|other| Self::can_collide(sprite, other))
@@ -102,7 +96,7 @@ impl BattleManager {
                         mutations.push(CollisionMutation::new(
                             &sprite.id,
                             &collided_sprite.id,
-                            sprite.attack_state.damage,
+                            sprite.attack_state.get_damage(),
                         ));
                     }
                 });

--- a/src/board.rs
+++ b/src/board.rs
@@ -93,9 +93,9 @@ impl Board {
     pub fn is_out_of_board(sprite: &Sprite, position: &Position) -> bool {
         let cell = DrawingState::get_active_cell(sprite);
 
-        position.top < 0.0
-            || position.left < 0.0
-            || position.left + cell.width > CANVAS_WIDTH_F64
-            || position.top + cell.height > CANVAS_HEIGHT_F64
+        position.top + cell.height < 0.0
+            || position.left + cell.width < 0.0
+            || position.left > CANVAS_WIDTH_F64
+            || position.top > CANVAS_HEIGHT_F64
     }
 }

--- a/src/game.rs
+++ b/src/game.rs
@@ -25,7 +25,6 @@ pub struct Game {
     fps: Fps,
 
     last_gc: f64,
-    internal_once: bool,
 }
 
 impl Game {
@@ -39,7 +38,6 @@ impl Game {
             mouse_position: Position::new(0.0, 0.0),
             sprites: vec![],
             last_gc: 0.0,
-            internal_once: false,
         }
     }
 
@@ -312,15 +310,13 @@ impl Game {
     }
 
     pub fn on_plant_shoot(&mut self, sprite_id: &String) {
-        if self.internal_once {
-            return;
-        }
-
         let shooting_plant_location = &self.get_sprite_by_id(sprite_id).board_location.clone();
 
         // Check if row contains an enemy
         let has_enemy_in_row = self.sprites.iter_mut().find(|sprite| {
-            sprite.sprite_type == SpriteType::Zombie
+            sprite.visible
+                && !sprite.attack_state.is_dead()
+                && sprite.sprite_type == SpriteType::Zombie
                 && sprite.board_location.row == shooting_plant_location.row
         });
 

--- a/src/game.rs
+++ b/src/game.rs
@@ -164,6 +164,7 @@ impl Game {
             Callback::ShowPlantsChooser => self.show_plants_chooser(),
             Callback::ResetPlantsChoose => self.reset_plants_choose(),
             Callback::EnterBattleAnimation => self.enter_battle_animation(),
+            Callback::StartBattleCallout => self.start_battle_callout(),
             Callback::StartBattle => self.start_battle(),
             Callback::ChooserSeedSelect => self.on_chooser_seed_click(sprite_id),
             Callback::PlantCardClick => self.on_plant_card_click(sprite_id),
@@ -219,6 +220,10 @@ impl Game {
 
     pub fn enter_battle_animation(&mut self) {
         BattleScene::enter(self)
+    }
+
+    pub fn start_battle_callout(&mut self) {
+        BattleScene::battle_callout(self);
     }
 
     pub fn start_battle(&mut self) {

--- a/src/game.rs
+++ b/src/game.rs
@@ -173,6 +173,7 @@ impl Game {
             Callback::ShovelDragEnd => self.on_shovel_drag_end(),
             Callback::Shoot => self.on_plant_shoot(sprite_id),
             Callback::GenerateSunFlowSun => log!("Trigger SunFlow Sun Generation"), // TODO - Call SunManager with sprite
+            Callback::CreateZombieHead => self.show_zombie_head(sprite_id),
         }
     }
 
@@ -329,6 +330,10 @@ impl Game {
         self.state.sun_state.add_score(50);
 
         self.remove_sprite_by_id(sprite_id);
+    }
+
+    pub fn show_zombie_head(&mut self, zombie_id: &String) {
+        BattleScene::build_zombie_head(self, zombie_id)
     }
 
     fn sprites_garbage_collector(&mut self) {

--- a/src/location_builder.rs
+++ b/src/location_builder.rs
@@ -46,13 +46,22 @@ impl LocationBuilder {
         Position::new(board_position.top, board_position.left + x_offset)
     }
 
-    pub fn align_sprite_to_cell(sprite: &Sprite, cell: &SpriteCell) -> Position {
+    pub fn align_sprite_after_cells_swap(
+        sprite: &Sprite,
+        cell: &SpriteCell,
+        old_cell: &SpriteCell,
+    ) -> Position {
         let current_position = &sprite.position;
 
         let board_position =
             Board::get_board_placement(cell, sprite.board_location.row, sprite.board_location.col);
 
-        Position::new(board_position.top, current_position.left)
+        let x_delta = match cell.width > old_cell.width {
+            true => cell.width - old_cell.width,
+            false => 0.0,
+        };
+
+        Position::new(board_position.top, current_position.left - x_delta)
     }
 
     fn rand_within_rand(min: f64, max: f64) -> f64 {

--- a/src/location_builder.rs
+++ b/src/location_builder.rs
@@ -46,6 +46,15 @@ impl LocationBuilder {
         Position::new(board_position.top, board_position.left + x_offset)
     }
 
+    pub fn align_sprite_to_cell(sprite: &Sprite, cell: &SpriteCell) -> Position {
+        let current_position = &sprite.position;
+
+        let board_position =
+            Board::get_board_placement(cell, sprite.board_location.row, sprite.board_location.col);
+
+        Position::new(board_position.top, current_position.left)
+    }
+
     fn rand_within_rand(min: f64, max: f64) -> f64 {
         let min = Math::ceil(min);
         let max = Math::floor(max);

--- a/src/location_builder.rs
+++ b/src/location_builder.rs
@@ -41,7 +41,7 @@ impl LocationBuilder {
 
         let board_position = Board::get_board_placement(zombie_cell, start_row, start_col);
 
-        let x_offset = Self::random_offset(0, 30);
+        let x_offset = Self::random_offset(0, 40);
 
         Position::new(board_position.top, board_position.left + x_offset)
     }

--- a/src/model.rs
+++ b/src/model.rs
@@ -67,6 +67,7 @@ pub enum Callback {
     ShovelDragEnd,
     Shoot,
     GenerateSunFlowSun,
+    CreateZombieHead,
 }
 
 impl Default for Callback {

--- a/src/model.rs
+++ b/src/model.rs
@@ -56,6 +56,7 @@ pub enum Callback {
     ShowPlantsChooser,
     ResetPlantsChoose,
     EnterBattleAnimation,
+    StartBattleCallout,
     StartBattle,
     ChooserSeedSelect,
     PlantCardClick,

--- a/src/scene/battle.rs
+++ b/src/scene/battle.rs
@@ -1,8 +1,6 @@
-use std::collections::HashMap;
-use js_sys::Math;
-
 use crate::game::Game;
 use crate::location_builder::LocationBuilder;
+use crate::log;
 use crate::model::BehaviorType::Walk;
 use crate::model::Callback::PlantCardClick;
 use crate::model::{BehaviorData, BehaviorType, Callback, Plant, Position, SelectedSeed, SpriteType};
@@ -64,6 +62,28 @@ impl BattleScene {
         });
 
         game.add_sprites(zombies.as_mut());
+    }
+
+    pub fn build_zombie_head(game: &mut Game, zombie_id: &String) {
+        let zombie_adjustment_position = Position::new(-60.0, 65.0);
+        let zombie_position = game.get_sprite_by_id(zombie_id).position.clone();
+        let now = game.game_time.time;
+
+        let mut sprites = Sprite::create_sprite("ZombieHead", &ResourceKind::Zombie, &game.resources);
+
+        sprites.iter_mut().for_each(|zombie| {
+            zombie.update_position(Position::new(
+                zombie_position.top + zombie_adjustment_position.top,
+                zombie_position.left + zombie_adjustment_position.left,
+            ));
+
+            zombie.sprite_type = SpriteType::Interface; // Avoid detected as Zombie
+        });
+
+        BehaviorManager::toggle_behaviors(&sprites, &[BehaviorType::Animate, Walk], true, now);
+
+        log!("Build head sfor Zombie {}", zombie_id);
+        game.add_sprites(sprites.as_mut());
     }
 
     pub fn prepare(game: &mut Game) {

--- a/src/scene/battle.rs
+++ b/src/scene/battle.rs
@@ -114,11 +114,8 @@ impl BattleScene {
             &game.resources,
         );
 
-        let mut battle_callout = Sprite::create_sprite(
-            "BattleCallout",
-            &ResourceKind::Interface,
-            &game.resources,
-        );
+        let mut battle_callout =
+            Sprite::create_sprite("BattleCallout", &ResourceKind::Interface, &game.resources);
 
         // Activates zombie hand animation Cycle.
         BehaviorManager::toggle_behaviors(
@@ -133,6 +130,10 @@ impl BattleScene {
     }
 
     pub fn start(game: &mut Game) {
+        game.get_sprites_by_type(&SpriteType::Zombie)
+            .iter_mut()
+            .for_each(|zombie| zombie.drawing_state.swap(0));
+
         game.toggle_game_behavior(true, &[BehaviorType::Collision, Walk]);
     }
 

--- a/src/scene/battle.rs
+++ b/src/scene/battle.rs
@@ -132,7 +132,9 @@ impl BattleScene {
     pub fn start(game: &mut Game) {
         game.get_sprites_by_type(&SpriteType::Zombie)
             .iter_mut()
-            .for_each(|zombie| zombie.drawing_state.swap(0));
+            .for_each(|zombie| {
+                zombie.update_swap_cell(0);
+            });
 
         game.toggle_game_behavior(true, &[BehaviorType::Collision, Walk]);
     }
@@ -166,7 +168,7 @@ impl BattleScene {
             original_position.top,
             original_position.left + drag_adjustment,
         ));
-        plant.order = 10; // TODO, Drag order based on behavior?
+        plant.order = 10; // TODO, Drag order based on behavior
 
         game.add_sprite(plant);
     }

--- a/src/scene/battle.rs
+++ b/src/scene/battle.rs
@@ -115,7 +115,7 @@ impl BattleScene {
         );
 
         let mut battle_callout = Sprite::create_sprite(
-            "PrepareGrowPlants",
+            "BattleCallout",
             &ResourceKind::Interface,
             &game.resources,
         );

--- a/src/scene/battle.rs
+++ b/src/scene/battle.rs
@@ -1,6 +1,5 @@
 use crate::game::Game;
 use crate::location_builder::LocationBuilder;
-use crate::log;
 use crate::model::BehaviorType::Walk;
 use crate::model::Callback::PlantCardClick;
 use crate::model::{BehaviorData, BehaviorType, Callback, Plant, Position, SelectedSeed, SpriteType};

--- a/src/scene/battle.rs
+++ b/src/scene/battle.rs
@@ -1,3 +1,6 @@
+use std::collections::HashMap;
+use js_sys::Math;
+
 use crate::game::Game;
 use crate::location_builder::LocationBuilder;
 use crate::model::BehaviorType::Walk;

--- a/src/sprite/attack_state.rs
+++ b/src/sprite/attack_state.rs
@@ -14,6 +14,13 @@ impl AttackState {
         }
     }
 
+    pub fn get_damage(&self) -> f64 {
+        match self.attack_enabled {
+            true => self.damage,
+            false => 0.0,
+        }
+    }
+
     pub fn take_damage(&mut self, damage: f64) {
         self.life -= damage;
     }

--- a/src/sprite/attack_state.rs
+++ b/src/sprite/attack_state.rs
@@ -25,7 +25,7 @@ impl AttackState {
         self.life -= damage;
     }
 
-    pub fn is_dead(&mut self) -> bool {
+    pub fn is_dead(&self) -> bool {
         self.life <= 0.0
     }
 

--- a/src/sprite/attack_state.rs
+++ b/src/sprite/attack_state.rs
@@ -2,11 +2,16 @@
 pub struct AttackState {
     pub life: f64,
     pub damage: f64,
+    pub attack_enabled: bool,
 }
 
 impl AttackState {
     pub fn new(life: f64, damage: f64) -> Self {
-        AttackState { life, damage }
+        AttackState {
+            life,
+            damage,
+            attack_enabled: true,
+        }
     }
 
     pub fn take_damage(&mut self, damage: f64) {
@@ -17,7 +22,7 @@ impl AttackState {
         self.life <= 0.0
     }
 
-    pub fn mute(&mut self) {
-        self.damage = 0.0;
+    pub fn mute(&mut self, enabled: bool) {
+        self.attack_enabled = enabled;
     }
 }

--- a/src/sprite/base.rs
+++ b/src/sprite/base.rs
@@ -220,7 +220,8 @@ impl Sprite {
 
             if let Some(swap_index) = mutation.swap {
                 if swap_index >= 0 {
-                    self.drawing_state.swap(swap_index as usize);
+                    self.drawing_state
+                        .swap(swap_index as usize);
                 } else {
                     self.drawing_state.reset_swap();
                 }

--- a/src/sprite/base.rs
+++ b/src/sprite/base.rs
@@ -6,7 +6,6 @@ use web_sys::HtmlImageElement;
 
 use crate::board::{Board, BoardLocation};
 use crate::location_builder::LocationBuilder;
-use crate::log;
 use crate::model::{
     BehaviorData, BehaviorType, CollisionMargin, Dimensions, Position, SpriteCell, SpriteData,
     SpriteType, TextOverlayData,

--- a/src/sprite/base.rs
+++ b/src/sprite/base.rs
@@ -5,6 +5,7 @@ use js_sys::Math;
 use web_sys::HtmlImageElement;
 
 use crate::board::{Board, BoardLocation};
+use crate::log;
 use crate::model::{
     BehaviorData, BehaviorType, CollisionMargin, Dimensions, Position, SpriteCell, SpriteData,
     SpriteType, TextOverlayData,
@@ -225,14 +226,14 @@ impl Sprite {
                 }
             }
 
-            if let Some(_) = mutation.mute {
-                self.attack_state.mute();
-                BehaviorManager::toggle_sprite_behaviors(
-                    self,
-                    &[BehaviorType::Walk],
-                    false,
-                    window_time(),
-                )
+            if let Some(walking) = mutation.walking {
+                self.toggle_walking(walking);
+            }
+
+            if let Some(mute) = mutation.mute {
+                log!("Setting mute mutation {} ", mute);
+                self.attack_state.mute(!mute);
+                self.toggle_walking(!mute);
             }
         });
     }
@@ -258,6 +259,10 @@ impl Sprite {
                     .margin,
             ),
         }
+    }
+
+    pub fn toggle_walking(&mut self, walking: bool) {
+        BehaviorManager::toggle_sprite_behaviors(self, &[BehaviorType::Walk], walking, window_time())
     }
 }
 

--- a/src/sprite/base.rs
+++ b/src/sprite/base.rs
@@ -231,7 +231,6 @@ impl Sprite {
             }
 
             if let Some(mute) = mutation.mute {
-                log!("Setting mute mutation {} ", mute);
                 self.attack_state.mute(!mute);
                 self.toggle_walking(!mute);
             }

--- a/src/sprite/base.rs
+++ b/src/sprite/base.rs
@@ -5,6 +5,7 @@ use js_sys::Math;
 use web_sys::HtmlImageElement;
 
 use crate::board::{Board, BoardLocation};
+use crate::location_builder::LocationBuilder;
 use crate::log;
 use crate::model::{
     BehaviorData, BehaviorType, CollisionMargin, Dimensions, Position, SpriteCell, SpriteData,
@@ -123,6 +124,18 @@ impl Sprite {
         self.board_location = Board::get_board_location(&sprite_center);
     }
 
+    pub fn update_swap_cell(&mut self, swap_index: i32) {
+        if swap_index >= 0 {
+            self.drawing_state.swap(swap_index as usize);
+        } else {
+            self.drawing_state.reset_swap();
+        }
+
+        // After swap, We need to re-place the sprite over the cell
+        let cell = DrawingState::get_active_cell(self);
+        self.update_position(LocationBuilder::align_sprite_to_cell(&self, cell));
+    }
+
     pub fn create_sprites(
         sprite_names: Vec<&str>,
         kind: &ResourceKind,
@@ -219,12 +232,7 @@ impl Sprite {
             }
 
             if let Some(swap_index) = mutation.swap {
-                if swap_index >= 0 {
-                    self.drawing_state
-                        .swap(swap_index as usize);
-                } else {
-                    self.drawing_state.reset_swap();
-                }
+                self.update_swap_cell(swap_index);
             }
 
             if let Some(walking) = mutation.walking {

--- a/src/sprite/behavior/animate.rs
+++ b/src/sprite/behavior/animate.rs
@@ -71,6 +71,7 @@ impl Behavior for Animate {
             if execute_callback {
                 self.stop(now);
                 self.interaction_active = true;
+                return Some(SpriteMutation::new().hide(true));
             }
 
             return None;

--- a/src/sprite/behavior/animate.rs
+++ b/src/sprite/behavior/animate.rs
@@ -33,6 +33,11 @@ impl Animate {
             ..Default::default()
         }
     }
+
+    pub fn set_max_cycles(&mut self, max_cycles: usize) {
+        self.finished_cycles = 0;
+        self.max_cycles = max_cycles;
+    }
 }
 
 impl Behavior for Animate {

--- a/src/sprite/behavior/collision/base.rs
+++ b/src/sprite/behavior/collision/base.rs
@@ -1,4 +1,4 @@
-use crate::log;
+use crate::model::Callback;
 use crate::sprite::{CollisionState, Sprite, SpriteMutation};
 use crate::timers::Timer;
 use crate::web_utils::window_time;
@@ -38,6 +38,10 @@ pub trait CollisionHandler {
     ) -> Option<SpriteMutation> {
         None
     }
+
+    fn get_interaction_callback(&mut self) -> Option<Callback> {
+        None
+    }
 }
 
 pub struct BulletCollisionHandler;
@@ -75,6 +79,7 @@ impl ZombieState {
 pub struct ZombieCollisionHandler {
     attack_timer: Timer,
     zombie_state: ZombieState,
+    lost_head: bool,
 }
 
 impl ZombieCollisionHandler {
@@ -82,6 +87,7 @@ impl ZombieCollisionHandler {
         ZombieCollisionHandler {
             attack_timer: Timer::new(2000.0),
             zombie_state: ZombieState::ArmoredWalk,
+            lost_head: false,
         }
     }
 
@@ -147,6 +153,17 @@ impl CollisionHandler for ZombieCollisionHandler {
             .mute(true)
             .swap(self.get_swap_index())
             .stop_animate()
+
+        // TODO - Build head animation? ( No game access here solely the id of it
+    }
+
+    fn get_interaction_callback(&mut self) -> Option<Callback> {
+        if self.zombie_state == ZombieState::Die && !self.lost_head {
+            self.lost_head = true;
+            return Some(Callback::CreateZombieHead);
+        }
+
+        None
     }
 
     fn on_collision_state_change(

--- a/src/sprite/behavior/collision/base.rs
+++ b/src/sprite/behavior/collision/base.rs
@@ -79,7 +79,7 @@ impl CollisionHandler for ZombieCollisionHandler {
 
         self.attack_timer.start();
 
-        SpriteMutation::new().mute(true)
+        SpriteMutation::new().mute(true).swap(-1)
     }
 
     fn on_hit(&mut self, damage: f64) -> SpriteMutation {
@@ -97,7 +97,7 @@ impl CollisionHandler for ZombieCollisionHandler {
     ) -> Option<SpriteMutation> {
         if state == &CollisionState::None && prev_state == &CollisionState::Attacking {
             self.attack_timer.stop(None);
-            return Some(SpriteMutation::new().mute(false));
+            return Some(SpriteMutation::new().mute(false).swap(0));
         }
 
         None

--- a/src/sprite/behavior/collision/base.rs
+++ b/src/sprite/behavior/collision/base.rs
@@ -1,5 +1,5 @@
 use crate::log;
-use crate::sprite::{CollisionState, SpriteMutation};
+use crate::sprite::{CollisionState, Sprite, SpriteMutation};
 use crate::timers::Timer;
 use crate::web_utils::window_time;
 
@@ -28,6 +28,7 @@ pub trait CollisionHandler {
 
     fn on_collision_state_change(
         &mut self,
+        _sprite: &Sprite,
         _state: &CollisionState,
         _prev_state: &CollisionState,
     ) -> Option<SpriteMutation> {
@@ -54,8 +55,8 @@ impl CollisionHandler for PlantCollisionHandler {}
 #[derive(Debug, Copy, Clone)]
 enum ZombieState {
     Stale = 0,
-    ArmoredAttack,
     ArmoredWalk,
+    ArmoredAttack,
     Walk,
     Attack,
     LostHead,
@@ -70,24 +71,36 @@ impl ZombieState {
 
 pub struct ZombieCollisionHandler {
     attack_timer: Timer,
-    zombie_state: ZombieState
+    zombie_state: ZombieState,
 }
 
 impl ZombieCollisionHandler {
     pub fn new() -> Self {
         ZombieCollisionHandler {
             attack_timer: Timer::new(2000.0),
-            zombie_state: ZombieState::Stale
+            zombie_state: ZombieState::ArmoredWalk,
         }
     }
 
-    fn get_zombie_state(&mut self, state: &CollisionState) -> ZombieState {
-        // needs life access
+    fn get_zombie_state(&mut self, state: &CollisionState, life: f64) -> ZombieState {
         match state {
-            CollisionState::None => ZombieState::Walk, // TODO - Or Armored Walk
-            CollisionState::Attacking => ZombieState::Attack, // Or ArmoredAttack
-            CollisionState::TakingDamage(_) => self.zombie_state.clone(), // Passive or Dead
+            CollisionState::None => match life < 100.0 {
+                true => ZombieState::Walk,
+                false => ZombieState::ArmoredWalk,
+            },
+            CollisionState::Attacking => match life < 100.0 {
+                true => ZombieState::Attack,
+                false => ZombieState::ArmoredAttack,
+            },
+            CollisionState::TakingDamage(_) => match life <= 0.0 {
+                true => ZombieState::Die,
+                false => self.zombie_state.clone(),
+            },
         }
+    }
+
+    fn get_swap_index(&mut self) -> i32 {
+        (self.zombie_state.index() - 1) as i32
     }
 }
 
@@ -108,11 +121,14 @@ impl CollisionHandler for ZombieCollisionHandler {
 
         self.attack_timer.start();
 
-        SpriteMutation::new().mute(true).swap(-1)
+        SpriteMutation::new().mute(true).swap(self.get_swap_index())
     }
 
     fn on_hit(&mut self, damage: f64) -> SpriteMutation {
-        SpriteMutation::new().damage(damage).alpha(0.5)
+        SpriteMutation::new()
+            .damage(damage)
+            .alpha(0.5)
+            .swap(self.get_swap_index())
     }
 
     fn on_after_hit(&mut self) -> DelayedMutation {
@@ -121,13 +137,15 @@ impl CollisionHandler for ZombieCollisionHandler {
 
     fn on_collision_state_change(
         &mut self,
+        sprite: &Sprite,
         state: &CollisionState,
         prev_state: &CollisionState,
     ) -> Option<SpriteMutation> {
-        let zombie_state = self.get_zombie_state(state);
+        let life = sprite.attack_state.life;
+        self.zombie_state = self.get_zombie_state(state, life);
         log!(
             "Zombie state is: {:?} / {:?} / {:?}",
-            zombie_state,
+            self.zombie_state,
             state,
             prev_state
         );
@@ -136,7 +154,11 @@ impl CollisionHandler for ZombieCollisionHandler {
             && self.attack_timer.running
         {
             self.attack_timer.stop(None);
-            return Some(SpriteMutation::new().mute(false).swap(0));
+            return Some(
+                SpriteMutation::new()
+                    .mute(false)
+                    .swap(self.get_swap_index()),
+            );
         }
 
         None

--- a/src/sprite/behavior/collision/base.rs
+++ b/src/sprite/behavior/collision/base.rs
@@ -1,33 +1,47 @@
-use crate::sprite::SpriteMutation;
+use crate::sprite::{CollisionState, SpriteMutation};
+use crate::timers::Timer;
+use crate::web_utils::window_time;
 
 pub type DelayedMutation = (Option<SpriteMutation>, f64);
 
 pub trait CollisionHandler {
-    fn on_attack(&self) -> SpriteMutation {
+    fn tick(&mut self) -> Option<SpriteMutation> {
+        None
+    }
+
+    fn on_attack(&mut self) -> SpriteMutation {
         SpriteMutation::new()
     }
 
-    fn on_after_attack(&self) -> DelayedMutation {
+    fn on_after_attack(&mut self) -> DelayedMutation {
         (Some(SpriteMutation::new()), 0.0)
     }
 
-    fn on_hit(&self, damage: f64) -> SpriteMutation {
+    fn on_hit(&mut self, damage: f64) -> SpriteMutation {
         SpriteMutation::new().damage(damage)
     }
 
-    fn on_after_hit(&self) -> DelayedMutation {
+    fn on_after_hit(&mut self) -> DelayedMutation {
         (Some(SpriteMutation::new()), 0.0)
+    }
+
+    fn on_collision_state_change(
+        &mut self,
+        _state: &CollisionState,
+        _prev_state: &CollisionState,
+    ) -> Option<SpriteMutation> {
+        None
     }
 }
 
 pub struct BulletCollisionHandler;
 
 impl CollisionHandler for BulletCollisionHandler {
-    fn on_attack(&self) -> SpriteMutation {
-        SpriteMutation::new().swap(0).mute()
+    fn on_attack(&mut self) -> SpriteMutation {
+        SpriteMutation::new().swap(0).mute(true)
     }
 
-    fn on_after_attack(&self) -> DelayedMutation {
+    fn on_after_attack(&mut self) -> DelayedMutation {
         (Some(SpriteMutation::new().hide(true)), 50.0)
     }
 }
@@ -36,14 +50,51 @@ pub struct PlantCollisionHandler;
 
 impl CollisionHandler for PlantCollisionHandler {}
 
-pub struct ZombieCollisionHandler;
+pub struct ZombieCollisionHandler {
+    timer: Timer,
+}
+
+impl ZombieCollisionHandler {
+    pub fn new() -> Self {
+        ZombieCollisionHandler {
+            timer: Timer::new(2000.0),
+        }
+    }
+}
 
 impl CollisionHandler for ZombieCollisionHandler {
-    fn on_hit(&self, damage: f64) -> SpriteMutation {
+    fn tick(&mut self) -> Option<SpriteMutation> {
+        if self.timer.expired(window_time()) {
+            self.timer.reset(None);
+            return Some(SpriteMutation::new().mute(false));
+        }
+
+        None
+    }
+
+    fn on_collision_state_change(
+        &mut self,
+        _state: &CollisionState,
+        prev_state: &CollisionState,
+    ) -> Option<SpriteMutation> {
+        if prev_state == &CollisionState::Attacking {
+            return Some(SpriteMutation::new().mute(false));
+        }
+
+        None
+    }
+
+    fn on_attack(&mut self) -> SpriteMutation {
+        self.timer.start();
+
+        SpriteMutation::new().mute(true)
+    }
+
+    fn on_hit(&mut self, damage: f64) -> SpriteMutation {
         SpriteMutation::new().damage(damage).alpha(0.5)
     }
 
-    fn on_after_hit(&self) -> DelayedMutation {
+    fn on_after_hit(&mut self) -> DelayedMutation {
         (Some(SpriteMutation::new().alpha(1.0)), 50.0)
     }
 }

--- a/src/sprite/behavior/collision/base.rs
+++ b/src/sprite/behavior/collision/base.rs
@@ -165,7 +165,6 @@ impl CollisionHandler for ZombieCollisionHandler {
             && self.attack_timer.running
         {
             self.attack_timer.stop(None);
-            log!("Zombie Stop Attack.");
             return Some(
                 SpriteMutation::new()
                     .mute(false)
@@ -175,11 +174,6 @@ impl CollisionHandler for ZombieCollisionHandler {
 
         // Internal Zombie state changes.
         if prev_zombie_state != self.zombie_state {
-            log!(
-                "Zombie Internal state change {:?} / {:?} ",
-                self.zombie_state,
-                prev_zombie_state
-            );
             return Some(SpriteMutation::new().swap(self.get_swap_index()));
         }
 

--- a/src/sprite/behavior/collision/mod.rs
+++ b/src/sprite/behavior/collision/mod.rs
@@ -126,12 +126,12 @@ impl Behavior for Collision {
         }
 
         if self.prev_state != self.state {
-            log!(
-                "State CHJANGE! {:?} / {:?} -- {}",
-                self.state,
-                self.prev_state,
-                sprite.id
-            );
+            let state_change_mutation =
+                collision_handler.on_collision_state_change(&self.state, &self.prev_state);
+
+            if state_change_mutation.is_some() {
+                return state_change_mutation;
+            }
         }
 
         // Handle Collision state hooks

--- a/src/sprite/behavior/collision/mod.rs
+++ b/src/sprite/behavior/collision/mod.rs
@@ -147,12 +147,6 @@ impl Behavior for Collision {
                 if damage > 0.0 {
                     mutation = Some(collision_handler.on_hit(damage));
 
-                    log!(
-                        "Taking damage {}, Remaining life / {}",
-                        damage,
-                        sprite.attack_state.life,
-                    );
-
                     let delayed_mutation = collision_handler.on_after_hit();
                     self.set_delayed_mutation(delayed_mutation);
                 }

--- a/src/sprite/behavior/collision/mod.rs
+++ b/src/sprite/behavior/collision/mod.rs
@@ -4,7 +4,6 @@ use derives::{derive_behavior_fields, BaseBehavior};
 use web_sys::CanvasRenderingContext2d;
 
 use super::base::Behavior;
-use crate::log;
 use crate::model::{BehaviorType, CollisionMargin, Position, SpriteType};
 use crate::sprite::behavior::collision::base::{
     BulletCollisionHandler, CollisionHandler, DelayedMutation, PlantCollisionHandler,

--- a/src/sprite/behavior/collision/mod.rs
+++ b/src/sprite/behavior/collision/mod.rs
@@ -127,7 +127,7 @@ impl Behavior for Collision {
 
         if self.prev_state != self.state {
             let state_change_mutation =
-                collision_handler.on_collision_state_change(&self.state, &self.prev_state);
+                collision_handler.on_collision_state_change(sprite, &self.state, &self.prev_state);
 
             if state_change_mutation.is_some() {
                 return state_change_mutation;

--- a/src/sprite/behavior/mod.rs
+++ b/src/sprite/behavior/mod.rs
@@ -8,9 +8,7 @@ pub use scroll::Scroll;
 pub use walk::Walk;
 use web_sys::CanvasRenderingContext2d;
 
-use crate::model::{
-    BehaviorData, BehaviorType, CollisionMargin, GameInteraction, Position,
-};
+use crate::model::{BehaviorData, BehaviorType, CollisionMargin, GameInteraction, Position};
 use crate::sprite::behavior::drag::Drag;
 use crate::sprite::{Sprite, SpriteMutation};
 use crate::timers::GameTime;

--- a/src/sprite/behavior/mod.rs
+++ b/src/sprite/behavior/mod.rs
@@ -9,7 +9,7 @@ pub use walk::Walk;
 use web_sys::CanvasRenderingContext2d;
 
 use crate::model::{
-    BehaviorData, BehaviorType, CollisionMargin, GameInteraction, Position, SpriteType,
+    BehaviorData, BehaviorType, CollisionMargin, GameInteraction, Position,
 };
 use crate::sprite::behavior::drag::Drag;
 use crate::sprite::{Sprite, SpriteMutation};

--- a/src/sprite/behavior/walk.rs
+++ b/src/sprite/behavior/walk.rs
@@ -3,7 +3,6 @@ use web_sys::CanvasRenderingContext2d;
 
 use super::base::Behavior;
 use crate::board::Board;
-use crate::log;
 use crate::model::{BehaviorType, Position, Velocity};
 use crate::sprite::{Sprite, SpriteMutation};
 
@@ -54,7 +53,6 @@ impl Behavior for Walk {
         let finished = self.max_distance > 0.0 && self.walked_distance.abs() >= self.max_distance;
 
         if finished {
-            log!("Walk finished!");
             self.stop(now);
             return None;
         }

--- a/src/sprite/behavior/walk.rs
+++ b/src/sprite/behavior/walk.rs
@@ -3,6 +3,7 @@ use web_sys::CanvasRenderingContext2d;
 
 use super::base::Behavior;
 use crate::board::Board;
+use crate::log;
 use crate::model::{BehaviorType, Position, Velocity};
 use crate::sprite::{Sprite, SpriteMutation};
 
@@ -53,6 +54,7 @@ impl Behavior for Walk {
         let finished = self.max_distance > 0.0 && self.walked_distance.abs() >= self.max_distance;
 
         if finished {
+            log!("Walk finished!");
             self.stop(now);
             return None;
         }

--- a/src/sprite/drawing_state.rs
+++ b/src/sprite/drawing_state.rs
@@ -1,4 +1,3 @@
-use crate::log;
 use crate::model::{Position, SpriteCell};
 use crate::sprite::Sprite;
 

--- a/src/sprite/drawing_state.rs
+++ b/src/sprite/drawing_state.rs
@@ -30,13 +30,17 @@ impl DrawingState {
         }
     }
 
+    pub fn get_cells(&self) -> &Vec<SpriteCell> {
+        match self.swap_index {
+            None => &self.cells,
+            Some(index) => &self.swap_cells[index],
+        }
+    }
+
     pub fn get_active_cell(sprite: &Sprite) -> &SpriteCell {
         let drawing_state = &sprite.drawing_state;
 
-        let cells = match drawing_state.swap_index {
-            None => &drawing_state.cells,
-            Some(index) => &drawing_state.swap_cells[index],
-        };
+        let cells = drawing_state.get_cells();
 
         let cell = cells.get(drawing_state.active_cell).expect(&format!(
             "[Sprite] Cannot get drawing state cell of {} / {} / {:?}",
@@ -71,7 +75,7 @@ impl DrawingState {
 
     pub fn cycle_cells(&mut self) {
         let current = self.active_cell;
-        let max = self.cells.len();
+        let max = self.get_cells().len();
 
         let next_index = match current < max - 1 {
             true => current + 1,
@@ -82,7 +86,7 @@ impl DrawingState {
     }
 
     pub fn in_last_cell(&self) -> bool {
-        self.active_cell == self.cells.len() - 1
+        self.active_cell == self.get_cells().len() - 1
     }
 
     fn set_cell(&mut self, index: usize) {

--- a/src/sprite/drawing_state.rs
+++ b/src/sprite/drawing_state.rs
@@ -1,3 +1,4 @@
+use crate::log;
 use crate::model::{Position, SpriteCell};
 use crate::sprite::Sprite;
 
@@ -46,13 +47,19 @@ impl DrawingState {
     }
 
     pub fn swap(&mut self, swap_index: usize) {
-        self.active_cell = 0;
-        self.swap_index = Some(swap_index);
+        if self.swap_index != Some(swap_index) {
+            log!("Swapping index!");
+            self.active_cell = 0;
+            self.swap_index = Some(swap_index);
+        }
     }
 
     pub fn reset_swap(&mut self) {
-        self.active_cell = 0;
-        self.swap_index = None;
+        if self.swap_index.is_some() {
+            log!("Reset index!");
+            self.active_cell = 0;
+            self.swap_index = None;
+        }
     }
 
     pub fn hover(&mut self, hover: bool) {

--- a/src/sprite/drawing_state.rs
+++ b/src/sprite/drawing_state.rs
@@ -48,7 +48,7 @@ impl DrawingState {
 
     pub fn swap(&mut self, swap_index: usize) {
         if self.swap_index != Some(swap_index) {
-            log!("Swapping index!");
+            log!("Swapping index! {}/ {}", swap_index);
             self.active_cell = 0;
             self.swap_index = Some(swap_index);
         }

--- a/src/sprite/drawing_state.rs
+++ b/src/sprite/drawing_state.rs
@@ -48,7 +48,6 @@ impl DrawingState {
 
     pub fn swap(&mut self, swap_index: usize) {
         if self.swap_index != Some(swap_index) {
-            log!("Swapping index! {}/ {}", swap_index);
             self.active_cell = 0;
             self.swap_index = Some(swap_index);
         }
@@ -56,7 +55,6 @@ impl DrawingState {
 
     pub fn reset_swap(&mut self) {
         if self.swap_index.is_some() {
-            log!("Reset index!");
             self.active_cell = 0;
             self.swap_index = None;
         }

--- a/src/sprite/mutations.rs
+++ b/src/sprite/mutations.rs
@@ -86,12 +86,6 @@ impl SpriteMutation {
         self
     }
 
-    pub fn toggle_walk(mut self, walking: bool) -> Self {
-        self.walking = Some(walking);
-
-        self
-    }
-
     pub fn stop_animate(mut self) -> Self {
         self.stop_animate = Some(true);
 

--- a/src/sprite/mutations.rs
+++ b/src/sprite/mutations.rs
@@ -11,6 +11,7 @@ pub struct SpriteMutation {
     pub mute: Option<bool>,
     pub damage: Option<f64>,
     pub alpha: Option<f64>,
+    pub walking: Option<bool>,
 }
 
 impl SpriteMutation {
@@ -25,6 +26,7 @@ impl SpriteMutation {
             swap: None,
             mute: None,
             alpha: None,
+            walking: None,
         }
     }
 
@@ -70,14 +72,20 @@ impl SpriteMutation {
         self
     }
 
-    pub fn mute(mut self) -> Self {
-        self.mute = Some(true);
+    pub fn mute(mut self, muted: bool) -> Self {
+        self.mute = Some(muted);
 
         self
     }
 
     pub fn alpha(mut self, alpha: f64) -> Self {
         self.alpha = Some(alpha);
+
+        self
+    }
+
+    pub fn toggle_walk(mut self, walking: bool) -> Self {
+        self.walking = Some(walking);
 
         self
     }

--- a/src/sprite/mutations.rs
+++ b/src/sprite/mutations.rs
@@ -12,6 +12,7 @@ pub struct SpriteMutation {
     pub damage: Option<f64>,
     pub alpha: Option<f64>,
     pub walking: Option<bool>,
+    pub stop_animate: Option<bool>,
 }
 
 impl SpriteMutation {
@@ -27,6 +28,7 @@ impl SpriteMutation {
             mute: None,
             alpha: None,
             walking: None,
+            stop_animate: None,
         }
     }
 
@@ -86,6 +88,12 @@ impl SpriteMutation {
 
     pub fn toggle_walk(mut self, walking: bool) -> Self {
         self.walking = Some(walking);
+
+        self
+    }
+
+    pub fn stop_animate(mut self) -> Self {
+        self.stop_animate = Some(true);
 
         self
     }

--- a/src/timers/base_timer.rs
+++ b/src/timers/base_timer.rs
@@ -30,6 +30,11 @@ impl Timer {
         self.start_time = self.get_current_time();
     }
 
+    pub fn stop(&mut self, now: Option<f64>) {
+        self.reset(now);
+        self.running = false;
+    }
+
     pub fn reset(&mut self, now: Option<f64>) {
         self.start_time = match now {
             Some(now) => now,


### PR DESCRIPTION
**Main changes**

- Fully implementing ZombiesCollision handler for Zombies battle animations + Death scenes.
- Collision handlers added a `on_die` hook to Implement their custom death logic + `on_collision_state_change` any time their state gets changed.
- Collision handlers now can set their `interaction` using a dedicate `get_interaction` hook.

**Side effects**
- BattleManager support multiple mutations per entity ( as it can be both attacked + attacking ).
- Better support for sprite cells swap, re-calculating the proper position according to last cell.
- `Animate` behavior supports changing its max_cycles.
- Battle `Callout` text phase added.
- Zombies data aligned.
- Drawing State now address `swap` cell in all of his internal methods. ( It was pointing on the original cell even once swapped )
- Fix `Location::out_of_board` logic, to take the most edge part of the sprite before deciding it out of board.